### PR TITLE
docs: Skills vs MCP explainer, collapsible agent guides, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Agent  →  MCP  →  SkillNote  →  Skills DB
 ```
 Every skill is exposed as an MCP tool. The agent discovers and calls them live: no files, no installs, always up to date. Update a skill in the Web UI and every connected agent gets the new version instantly.
 
+> **No restart required.** The MCP server queries the database on every `tools/list` request — there is no in-memory cache. Create or update a skill and it is available to all connected agents on their very next call, with zero downtime.
+
 ```
 ┌──────────┐     tools/list      ┌───────────────┐
 │  Agent   │ ─────────────────▶  │  SkillNote    │

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ Open **http://localhost:3000** and start creating skills.
 
 ---
 
-## Skills vs MCP — What's the Difference?
+## Skills vs MCP: What's the Difference?
 
 > Most people building AI agents hear about both and assume they're the same thing. They're not. Understanding the difference is what makes SkillNote click.
 
 ### Skills: reusable intelligence
 
-A Skill is a reusable piece of knowledge injected into an agent's context — instructions, workflows, rules, examples. Think of it as a dynamic system prompt loaded on demand:
+A Skill is a reusable piece of knowledge injected into an agent's context: instructions, workflows, rules, examples. Think of it as a dynamic system prompt loaded on demand:
 
 ```
 User message
@@ -99,7 +99,7 @@ Skills improve **reasoning**. They teach the agent *how* to do something.
 
 ### MCP: context transport
 
-[Model Context Protocol](https://modelcontextprotocol.io) is a standard for delivering context to agents — tools, APIs, documents, prompts. It improves **connectivity**. It doesn't care what the content is; it's the pipe.
+[Model Context Protocol](https://modelcontextprotocol.io) is a standard for delivering context to agents: tools, APIs, documents, prompts. It improves **connectivity**. It doesn't care what the content is; it's the pipe.
 
 ```
 Skills = HTML    (the content)
@@ -110,17 +110,17 @@ HTTP delivers HTML. But HTML isn't part of HTTP. Same relationship.
 
 ### How SkillNote combines both
 
-**Version 1 — local files:**
+**Version 1: local files:**
 ```
 Agent reads skills/making-tea/SKILL.md from disk
 ```
 Simple. Works offline. But skills go stale, drift across machines, and require manual installs.
 
-**Version 2 — MCP delivery (what SkillNote does):**
+**Version 2: MCP delivery (what SkillNote does):**
 ```
 Agent  →  MCP  →  SkillNote  →  Skills DB
 ```
-Every skill is exposed as an MCP tool. The agent discovers and calls them live — no files, no installs, always up to date. Update a skill in the Web UI and every connected agent gets the new version instantly.
+Every skill is exposed as an MCP tool. The agent discovers and calls them live: no files, no installs, always up to date. Update a skill in the Web UI and every connected agent gets the new version instantly.
 
 ```
 ┌──────────┐     tools/list      ┌───────────────┐
@@ -136,7 +136,7 @@ Every skill is exposed as an MCP tool. The agent discovers and calls them live �
 
 | | Local Skills | MCP Skills (SkillNote) |
 |---|---|---|
-| Updates | Manual (`git pull` / `npx install`) | Automatic — edit in UI, live instantly |
+| Updates | Manual (`git pull` / `npx install`) | Automatic: edit in UI, live instantly |
 | Fragmentation | Different versions per machine | One source of truth |
 | Discovery | Agent must know the file path | Agent discovers via `tools/list` |
 | Sharing | Send files or links | Connect to the same server |
@@ -146,7 +146,7 @@ Every skill is exposed as an MCP tool. The agent discovers and calls them live �
 
 ## MCP Server
 
-SkillNote exposes every skill as an MCP tool your agent can discover and call directly — no local files needed, no restart when skills change.
+SkillNote exposes every skill as an MCP tool your agent can discover and call directly: no local files needed, no restart when skills change.
 
 **How it works:**
 - Each skill becomes a tool: `name = slug`, `description = skill description`
@@ -625,20 +625,20 @@ docker compose up --build -d
 - [x] Version history with restore
 - [x] Tags and collections
 - [x] REST API (CRUD, versioning, publish pipeline)
-- [x] MCP server — expose all skills as tools for any AI agent
+- [x] MCP server: expose all skills as tools for any AI agent
 - [x] One-command Docker Compose stack (postgres + api + mcp + web)
 - [x] CLI skill installer (`npx skillnote`)
 - [x] Multi-agent connect guide (Claude Code, OpenClaw, Cursor, Windsurf)
 
 ### Up Next
 
-- [ ] **Redis caching** — cache skill listings and content in Redis to cut MCP `tools/list` and tool-call latency; skills invalidated on create/update/delete
-- [ ] **Collection-scoped MCP mounts** — mount a single collection as an MCP server so agents only see relevant skills
-- [ ] **Skill search and semantic ranking** — full-text and embedding-based search in the Web UI and via MCP
-- [ ] **Skill dependencies** — declare that one skill requires another; agents resolve the full tree automatically
-- [ ] **Webhook on skill publish** — notify CI or agent pipelines when a new skill version is published
-- [ ] **Role-based access control** — read-only vs editor vs admin roles with API tokens
-- [ ] **Import from GitHub** — sync a skills repo directly into SkillNote via URL
+- [ ] **Redis caching**: cache skill listings and content in Redis to cut MCP `tools/list` and tool-call latency; skills invalidated on create/update/delete
+- [ ] **Collection-scoped MCP mounts**: mount a single collection as an MCP server so agents only see relevant skills
+- [ ] **Skill search and semantic ranking**: full-text and embedding-based search in the Web UI and via MCP
+- [ ] **Skill dependencies**: declare that one skill requires another; agents resolve the full tree automatically
+- [ ] **Webhook on skill publish**: notify CI or agent pipelines when a new skill version is published
+- [ ] **Role-based access control**: read-only vs editor vs admin roles with API tokens
+- [ ] **Import from GitHub**: sync a skills repo directly into SkillNote via URL
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Agent  →  MCP  →  SkillNote  →  Skills DB
 ```
 Every skill is exposed as an MCP tool. The agent discovers and calls them live: no files, no installs, always up to date. Update a skill in the Web UI and every connected agent gets the new version instantly.
 
-> **No restart required.** The MCP server queries the database on every `tools/list` request — there is no in-memory cache. Create or update a skill and it is available to all connected agents on their very next call, with zero downtime.
+> **No restart required.** The MCP server queries the database on every `tools/list` request. There is no in-memory cache. Create or update a skill and it is available to all connected agents on their very next call, with zero downtime.
 
 ```
 ┌──────────┐     tools/list      ┌───────────────┐

--- a/README.md
+++ b/README.md
@@ -77,9 +77,76 @@ Open **http://localhost:3000** and start creating skills.
 
 ---
 
+## Skills vs MCP — What's the Difference?
+
+> Most people building AI agents hear about both and assume they're the same thing. They're not. Understanding the difference is what makes SkillNote click.
+
+### Skills: reusable intelligence
+
+A Skill is a reusable piece of knowledge injected into an agent's context — instructions, workflows, rules, examples. Think of it as a dynamic system prompt loaded on demand:
+
+```
+User message
+    ↓
+Agent picks the right Skill
+    ↓
+Injects SKILL.md content into the prompt
+    ↓
+LLM responds with that context
+```
+
+Skills improve **reasoning**. They teach the agent *how* to do something.
+
+### MCP: context transport
+
+[Model Context Protocol](https://modelcontextprotocol.io) is a standard for delivering context to agents — tools, APIs, documents, prompts. It improves **connectivity**. It doesn't care what the content is; it's the pipe.
+
+```
+Skills = HTML    (the content)
+MCP    = HTTP    (the transport)
+```
+
+HTTP delivers HTML. But HTML isn't part of HTTP. Same relationship.
+
+### How SkillNote combines both
+
+**Version 1 — local files:**
+```
+Agent reads skills/making-tea/SKILL.md from disk
+```
+Simple. Works offline. But skills go stale, drift across machines, and require manual installs.
+
+**Version 2 — MCP delivery (what SkillNote does):**
+```
+Agent  →  MCP  →  SkillNote  →  Skills DB
+```
+Every skill is exposed as an MCP tool. The agent discovers and calls them live — no files, no installs, always up to date. Update a skill in the Web UI and every connected agent gets the new version instantly.
+
+```
+┌──────────┐     tools/list      ┌───────────────┐
+│  Agent   │ ─────────────────▶  │  SkillNote    │
+│          │ ◀─────────────────  │  MCP Server   │
+│          │   [all your skills] │               │
+│          │                     │  reads from   │
+│          │  tools/call         │  PostgreSQL   │
+│          │ ─────────────────▶  │  on every     │
+│          │ ◀─────────────────  │  request      │
+└──────────┘   skill content     └───────────────┘
+```
+
+| | Local Skills | MCP Skills (SkillNote) |
+|---|---|---|
+| Updates | Manual (`git pull` / `npx install`) | Automatic — edit in UI, live instantly |
+| Fragmentation | Different versions per machine | One source of truth |
+| Discovery | Agent must know the file path | Agent discovers via `tools/list` |
+| Sharing | Send files or links | Connect to the same server |
+| Offline | Yes | Needs network |
+
+---
+
 ## MCP Server
 
-SkillNote includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) server. Instead of installing skill files locally, your agent connects to SkillNote directly and gets every skill as a callable tool, live from the database with no restart needed when skills change.
+SkillNote exposes every skill as an MCP tool your agent can discover and call directly — no local files needed, no restart when skills change.
 
 **How it works:**
 - Each skill becomes a tool: `name = slug`, `description = skill description`


### PR DESCRIPTION
## Summary

- Add "Skills vs MCP" explainer section clarifying the common confusion between the two (Skills = content/intelligence, MCP = transport layer, HTML/HTTP analogy)
- Make each agent connection guide collapsible using `<details>` blocks
- Replace Windsurf with OpenHands, Codex, and Antigravity in agent examples
- Add Roadmap section with done items and up-next priorities (including Redis caching for MCP)
- Improve `start.sh` with step-by-step logs and a "What to do next" guide
- Remove all internal planning/blueprint docs (8 files)
- Remove all em-dashes
- Resolve merge conflicts with master

## Test plan

- [x] 51 unit tests passing
- [x] 11 integration tests passing
- [x] 20 MCP E2E tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)