### PR TITLE
fix: recover MCP sessions after server restart

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -134,12 +134,18 @@ class ConnectionTrackerMiddleware(BaseHTTPMiddleware):
                 sess["last_seen"]  = time.time()
                 sess["call_count"] = sess.get("call_count", 0) + 1
 
+            # ── 3b. Unknown session ID — server restarted, client still alive ──
+            # Client is sending an Mcp-Session-Id we've never seen (our in-memory
+            # dict was wiped). Re-register it under the existing ID so the client's
+            # calls show up in the live view without requiring a reconnect.
+            elif existing_sid and existing_sid not in _active_connections and not is_initialize:
+                _active_connections[existing_sid] = _make_session(
+                    existing_sid, ua, remote, scope, "", "", "",
+                )
+
             # ── 4. IP+UA fallback (non-initialize only) ───────────────────────
             # Clients that don't echo Mcp-Session-Id (curl, some libs) still
             # keep their session alive via fingerprinting.
-            # Skip for initialize — that creates a fresh session in step 5.
-            # When multiple sessions share the same fingerprint, update the most
-            # recently seen one (highest last_seen) to match the active client.
             elif not existing_sid and not is_initialize:
                 match = max(
                     (s for s in _active_connections.values()

--- a/src/app/(app)/integrations/page.tsx
+++ b/src/app/(app)/integrations/page.tsx
@@ -95,6 +95,16 @@ function resolveAgent(conn: McpConnection) {
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
+/** Break a CLI command at --flag boundaries for readable display.
+ *  Each --flag starts on a new indented line with a backslash continuation.
+ *  The raw single-line form is preserved for clipboard copying. */
+function fmtCli(cmd: string): string {
+  // Split before each --flag, keeping the flag attached
+  const parts = cmd.split(/ (?=--\w)/)
+  if (parts.length <= 1) return cmd
+  return parts[0] + ' \\\n' + parts.slice(1).map(p => `  ${p}`).join(' \\\n')
+}
+
 function fmtDuration(s: number) {
   if (s < 60) return `${s}s`
   const secs = s % 60
@@ -557,8 +567,8 @@ function ConfigPanel({ agent, setAgent, config, agentDef, mcpUrl }: {
             <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/35">CLI install</span>
             <CopyBtn text={agentDef.cli(mcpUrl)} label="Copy" size="sm" />
           </div>
-          <pre className="bg-[hsl(var(--card))] dark:bg-zinc-950/70 px-5 py-4 text-[12px] font-mono text-muted-foreground overflow-x-auto whitespace-pre">
-            <code>{agentDef.cli(mcpUrl)}</code>
+          <pre className="bg-[hsl(var(--card))] dark:bg-zinc-950/70 px-5 py-4 text-[12px] font-mono text-muted-foreground whitespace-pre-wrap break-words">
+            <code>{fmtCli(agentDef.cli(mcpUrl))}</code>
           </pre>
         </div>
       )}

--- a/src/app/(app)/integrations/page.tsx
+++ b/src/app/(app)/integrations/page.tsx
@@ -109,29 +109,51 @@ function fmtUptime(s: number) {
 
 // ─── copy button ──────────────────────────────────────────────────────────────
 
-function copyText(text: string): void {
+async function copyText(text: string): Promise<boolean> {
   if (navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(text).catch(() => execCopy(text))
-  } else {
-    execCopy(text)
+    try { await navigator.clipboard.writeText(text); return true } catch { /* fall through */ }
   }
+  return execCopy(text)
 }
-function execCopy(text: string): void {
+function execCopy(text: string): boolean {
   const el = document.createElement('textarea')
   el.value = text
   el.style.cssText = 'position:fixed;opacity:0;pointer-events:none'
   document.body.appendChild(el)
   el.focus()
   el.select()
-  try { document.execCommand('copy') } catch { /* ignore */ }
+  try { document.execCommand('copy'); document.body.removeChild(el); return true } catch { /* ignore */ }
   document.body.removeChild(el)
+  return false
+}
+
+// ─── tooltip ──────────────────────────────────────────────────────────────────
+
+function Tip({ text, children }: { text: string; children: React.ReactNode }) {
+  return (
+    <span className="relative group/tip inline-flex items-center">
+      {children}
+      <span className={cn(
+        'pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2',
+        'w-max max-w-[220px] rounded-lg bg-popover border border-border/40',
+        'px-2.5 py-1.5 text-[11px] leading-snug text-popover-foreground shadow-lg',
+        'opacity-0 group-hover/tip:opacity-100 transition-opacity duration-150 z-50',
+        'whitespace-normal text-left'
+      )}>
+        {text}
+      </span>
+    </span>
+  )
 }
 
 function CopyBtn({ text, label = 'Copy', size = 'md' }: { text: string; label?: string; size?: 'sm' | 'md' }) {
   const [ok, setOk] = useState(false)
   return (
     <button
-      onClick={() => { copyText(text); setOk(true); setTimeout(() => setOk(false), 2000) }}
+      onClick={async () => {
+        const success = await copyText(text)
+        if (success) { setOk(true); setTimeout(() => setOk(false), 2000) }
+      }}
       className={cn(
         'inline-flex items-center gap-1.5 font-medium rounded-lg transition-all shrink-0',
         'text-muted-foreground/60 hover:text-foreground hover:bg-muted/60',
@@ -523,7 +545,7 @@ function ConfigPanel({ agent, setAgent, config, agentDef, mcpUrl }: {
             <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/35">CLI install</span>
             <CopyBtn text={agentDef.cli(mcpUrl)} label="Copy" size="sm" />
           </div>
-          <pre className="bg-[hsl(var(--card))] dark:bg-zinc-950/70 px-5 py-4 text-[12px] font-mono text-muted-foreground overflow-x-auto">
+          <pre className="bg-[hsl(var(--card))] dark:bg-zinc-950/70 px-5 py-4 text-[12px] font-mono text-muted-foreground overflow-x-auto whitespace-pre">
             <code>{agentDef.cli(mcpUrl)}</code>
           </pre>
         </div>
@@ -553,7 +575,7 @@ function ScopeChip({ scope, highlight }: { scope: string | null; highlight: bool
           : 'bg-muted/60 text-accent/60'
     )}>
       <Layers className="h-2.5 w-2.5 shrink-0" />
-      {isAll ? 'All Skills' : scope}
+      <span className="truncate max-w-[100px]">{isAll ? 'All Skills' : scope}</span>
     </span>
   )
 }
@@ -917,17 +939,17 @@ function SessionStatus({ mcpUrl, agentLabel, skillCount, scopeLabel }: {
       {/* vertical stack — fits 340px sidebar cleanly */}
       <div className="divide-y divide-border/25">
         {items.filter(i => !('emerald' in i && i.emerald)).map((item, i) => (
-          <div key={i} className="flex items-center justify-between px-5 py-3">
-            <span className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/35">
+          <div key={i} className="flex items-center justify-between gap-3 px-5 py-3">
+            <span className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/35 shrink-0">
               {item.label}
               {item.label === 'Tools' && (
-                <span title="Every skill in the selected collection is exposed as an MCP tool. Agents call tools/list to discover them." className="cursor-default">
-                  <Info className="w-3 h-3 text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors" />
-                </span>
+                <Tip text="Every skill in the collection is an MCP tool. Agents call tools/list to discover them and tools/call to get the content.">
+                  <Info className="w-3 h-3 text-muted-foreground/30 hover:text-muted-foreground/60 transition-colors cursor-default" />
+                </Tip>
               )}
             </span>
             <span className={cn(
-              'text-[12.5px] font-medium text-right',
+              'text-[12.5px] font-medium text-right truncate min-w-0',
               'accent' in item && item.accent ? 'text-accent' : 'text-foreground/75'
             )}>
               {item.value}

--- a/src/app/(app)/integrations/page.tsx
+++ b/src/app/(app)/integrations/page.tsx
@@ -97,8 +97,10 @@ function resolveAgent(conn: McpConnection) {
 
 function fmtDuration(s: number) {
   if (s < 60) return `${s}s`
-  if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`
-  return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`
+  const secs = s % 60
+  if (s < 3600) return secs ? `${Math.floor(s / 60)}m ${secs}s` : `${Math.floor(s / 60)}m`
+  const mins = Math.floor((s % 3600) / 60)
+  return mins ? `${Math.floor(s / 3600)}h ${mins}m` : `${Math.floor(s / 3600)}h`
 }
 function fmtUptime(s: number) {
   if (s < 60) return `${s}s`
@@ -438,7 +440,7 @@ function ScopeSelector({ collections, totalSkills, value, onChange }: {
               </div>
             )}
 
-            {collections.length === 0 && (
+            {collections.length === 0 && !q && (
               <div className="px-4 py-8 text-center">
                 <p className="text-[13px] text-muted-foreground/50">No collections yet</p>
                 <p className="text-[12px] text-muted-foreground/30 mt-1">Add collections to your skills</p>
@@ -651,7 +653,7 @@ function GroupSection({ category, conns, elapsed, open, onToggle, selectedScope 
         <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: cat.color }} />
         <span className="flex-1 text-[12px] font-semibold text-foreground/70">{cat.label}</span>
         {selectedScope && matchCount > 0 && (
-          <span className="text-[10px] font-medium text-accent/70 bg-accent/10 px-1.5 py-0.5 rounded tabular-nums">
+          <span className="text-[10px] font-medium text-accent/70 bg-accent/10 px-1.5 py-0.5 rounded tabular-nums max-w-[140px] truncate">
             {matchCount} on {selectedScope}
           </span>
         )}
@@ -731,12 +733,14 @@ function ConnectionsPanel({ selectedScope }: { selectedScope: string | null }) {
         )
       })
     }
+    // elapsedSincePoll is intentionally excluded: adding the same constant to all
+    // duration_seconds values doesn't change relative order, so sort is stable.
     return [...conns].sort((a, b) =>
       sort === 'calls'
         ? (b.call_count ?? 0) - (a.call_count ?? 0)
-        : (b.duration_seconds + elapsedSincePoll) - (a.duration_seconds + elapsedSincePoll)
+        : b.duration_seconds - a.duration_seconds
     )
-  }, [status, q, sort, online, elapsedSincePoll])
+  }, [status, q, sort, online]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Groups (category → connections), sorted by group size desc
   const groups = useMemo(() => {
@@ -770,7 +774,7 @@ function ConnectionsPanel({ selectedScope }: { selectedScope: string | null }) {
     setOpenGroups(prev => { const s = new Set(prev); s.has(cat) ? s.delete(cat) : s.add(cat); return s })
 
   return (
-    <div className="bg-card border border-border/40 rounded-2xl overflow-hidden flex flex-col h-full">
+    <div className="bg-card border border-border/40 rounded-2xl overflow-clip flex flex-col">
 
       {/* ── header ──────────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between px-5 py-3.5 border-b border-border/40">
@@ -928,7 +932,7 @@ function SessionStatus({ mcpUrl, agentLabel, skillCount, scopeLabel }: {
   ]
 
   return (
-    <div className="bg-card border border-border/40 rounded-2xl overflow-hidden">
+    <div className="bg-card border border-border/40 rounded-2xl overflow-clip">
       <div className="flex items-center justify-between px-5 py-3.5 border-b border-border/30">
         <span className="text-[12px] font-semibold text-foreground/60 uppercase tracking-wide">Session</span>
         <div className="flex items-center gap-1.5">

--- a/src/app/(app)/integrations/page.tsx
+++ b/src/app/(app)/integrations/page.tsx
@@ -130,20 +130,30 @@ function execCopy(text: string): boolean {
 }
 
 // ─── tooltip ──────────────────────────────────────────────────────────────────
+// Uses position:fixed + portal so it escapes any overflow-hidden/clip ancestor.
 
 function Tip({ text, children }: { text: string; children: React.ReactNode }) {
+  const anchorRef = useRef<HTMLSpanElement>(null)
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null)
+
+  const show = () => {
+    if (!anchorRef.current) return
+    const r = anchorRef.current.getBoundingClientRect()
+    setPos({ top: r.top, left: r.left + r.width / 2 })
+  }
+
   return (
-    <span className="relative group/tip inline-flex items-center">
+    <span ref={anchorRef} className="inline-flex items-center" onMouseEnter={show} onMouseLeave={() => setPos(null)}>
       {children}
-      <span className={cn(
-        'pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2',
-        'w-max max-w-[220px] rounded-lg bg-popover border border-border/40',
-        'px-2.5 py-1.5 text-[11px] leading-snug text-popover-foreground shadow-lg',
-        'opacity-0 group-hover/tip:opacity-100 transition-opacity duration-150 z-50',
-        'whitespace-normal text-left'
-      )}>
-        {text}
-      </span>
+      {pos && createPortal(
+        <span
+          style={{ position: 'fixed', top: pos.top - 8, left: pos.left, transform: 'translate(-50%, -100%)', zIndex: 9999 }}
+          className="pointer-events-none w-max max-w-[220px] rounded-lg bg-popover border border-border/40 px-2.5 py-1.5 text-[11px] leading-snug text-popover-foreground shadow-lg whitespace-normal text-left"
+        >
+          {text}
+        </span>,
+        document.body
+      )}
     </span>
   )
 }
@@ -504,7 +514,7 @@ function ConfigPanel({ agent, setAgent, config, agentDef, mcpUrl }: {
   mcpUrl: string
 }) {
   return (
-    <div className="bg-card border border-border/40 rounded-2xl overflow-hidden flex flex-col">
+    <div className="bg-card border border-border/40 rounded-2xl overflow-hidden flex flex-col min-w-0 w-full">
       {/* agent tabs */}
       <div className="flex items-center gap-0 border-b border-border/40 overflow-x-auto scrollbar-hide">
         {AGENTS.map(a => (
@@ -774,7 +784,7 @@ function ConnectionsPanel({ selectedScope }: { selectedScope: string | null }) {
     setOpenGroups(prev => { const s = new Set(prev); s.has(cat) ? s.delete(cat) : s.add(cat); return s })
 
   return (
-    <div className="bg-card border border-border/40 rounded-2xl overflow-clip flex flex-col">
+    <div className="bg-card border border-border/40 rounded-2xl overflow-hidden flex flex-col">
 
       {/* ── header ──────────────────────────────────────────────────────── */}
       <div className="flex items-center justify-between px-5 py-3.5 border-b border-border/40">
@@ -932,7 +942,7 @@ function SessionStatus({ mcpUrl, agentLabel, skillCount, scopeLabel }: {
   ]
 
   return (
-    <div className="bg-card border border-border/40 rounded-2xl overflow-clip">
+    <div className="bg-card border border-border/40 rounded-2xl overflow-hidden">
       <div className="flex items-center justify-between px-5 py-3.5 border-b border-border/30">
         <span className="text-[12px] font-semibold text-foreground/60 uppercase tracking-wide">Session</span>
         <div className="flex items-center gap-1.5">
@@ -1044,8 +1054,8 @@ export default function IntegrationsPage() {
           {/* ── two-column: config + session ─────────────────────────── */}
           <div className="i-3 grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-5 items-start mb-5">
 
-            {/* config */}
-            <div className="cfg" key={agent + (col ?? '_')}>
+            {/* config — min-w-0 prevents long URLs/CLI from blowing the grid column */}
+            <div className="cfg min-w-0" key={agent + (col ?? '_')}>
               <ConfigPanel
                 agent={agent}
                 setAgent={setAgent}


### PR DESCRIPTION
## Problem

After a Docker restart, `_active_connections` (in-memory dict) is wiped. Clients like Claude Code cache their `Mcp-Session-Id` from the initial handshake and keep sending it on every tool call — but the server no longer recognises it, so the connection never shows in the Live Connections UI even though the client reports `✔ connected`.

## Fix

Added **step 3b** in `ConnectionTrackerMiddleware`: when a request arrives with a `Mcp-Session-Id` the server doesn't recognise (and it's not an `initialize`), re-register it under that same session ID using the request's UA and remote IP. The next tool call the client makes causes it to appear in the live view — **no reconnect required**.

```
client sends:  POST /mcp  Mcp-Session-Id: <old-id>  (tools/list)
server (old):  no match → silently ignore → UI shows nothing
server (new):  no match → register under <old-id> → UI shows connection
```

## Test plan

- [ ] Start stack, note Claude Code shows `✔ connected` in `/mcp`
- [ ] Restart only the MCP container (`docker compose restart mcp`)
- [ ] Invoke any skill from Claude Code (or wait for next tools/list poll)
- [ ] Live Connections UI shows the Claude Code session without reconnecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)