### PR TITLE
feat: skill rating via MCP complete_skill tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,54 @@
+# Dependencies
 node_modules/
+
+# Next.js
 .next/
-test-results/
-tests/
-!backend/tests/
-!backend/tests/**
-qa-*.mjs
-audit*.mjs
-mobile-audit*.js
-r7-test.js
-PROMPT.md
-*PROMPT.md
-skillvault-backup-*.tar.gz
-*.log
+out/
+
+# Build
+dist/
+tsconfig.tsbuildinfo
+
+# Environment
 .env
 .env.local
-tsconfig.tsbuildinfo
+.env.*.local
+
+# Testing
+test-results/
+playwright-report/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+*.egg-info/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+
+# Temporary files
+*.tmp
+.temp/
+
+# Docker volumes (local data)
+postgres-data/
+
+# Ralph
+.ralph/
+.ralphrc
+.ralph_backup_*
+
+# Rust (if using CLI builds)
+target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,109 @@
 # Changelog
 
 All notable changes to SkillNote will be documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.1.0] - 2026-03-08
+## [0.2.0] - 2026-03-08
 
 ### Added
-- Skill registry with offline-first localStorage + PostgreSQL sync
-- SKILL.md import/export with YAML frontmatter
-- Content versioning with history, compare, and restore
-- MCP server for AI agent integration (Claude Code, Cursor, Codex, OpenHands)
+- Dynamic app versioning — version sourced from `package.json`, displayed in sidebar and settings
+- `CHANGELOG.md` for tracking releases
+
+### Fixed
+- Port collision on startup — `start.sh` now ensures ports are fully released before launching containers
+- `.gitignore` rewritten with proper entries for Next.js, Python, env files, and build artifacts
+
+## [0.1.0] - 2026-03-07
+
+### Added
 - Skill rating and completion tracking via `complete_skill` MCP tool
-- Analytics dashboard with usage trends and agent breakdowns
-- MCP Integrations page showing connected agents
-- Collections for organizing skills
-- Command palette with keyboard shortcuts
-- Settings page with MCP tool configuration
-- Docker Compose deployment (postgres, api, mcp, web)
-- CLI tool with agent adapters
+- Settings page with MCP tool toggles (completion tracking, outcome field)
+- Settings API backend (`/v1/settings`)
+
+## [0.0.9] - 2026-03-06
+
+### Added
+- Analytics dashboard with recharts visualizations and usage trends
+- Real-time `notifications/tools/list_changed` for MCP clients
+
+## [0.0.8] - 2026-03-05
+
+### Fixed
+- MCP session recovery after server restart without requiring reconnect
+- Tooltip portal and grid layout stability
+- Session overflow, copy reliability, chip truncation bugs
+
+## [0.0.7] - 2026-03-04
+
+### Added
+- MCP Integrations page with live connection tracking and agent identity
+- Rich connection identity and scalable 100+ connection UI
+- CLI install command row for agents that support it
+- Collection scope context in live connections panel
+
+### Fixed
+- Session stays visible with 30min timeout + pre-create on initialize
+- Copy buttons work on non-HTTPS LAN origins
+
+## [0.0.6] - 2026-03-03
+
+### Added
+- Collection UX overhaul — Notion-style design, inline confirm, smart picker
+- Collection membership shown on skill list and detail views
+- Inline remove confirmation in AddSkillsModal
+
+### Changed
+- Removed tags system, replaced with skills-to-collection UI
+- Dropped tags from SQLAlchemy ORM models to match DB schema
+
+## [0.0.5] - 2026-03-02
+
+### Added
+- MCP server exposing skills as tools (`/mcp` endpoint)
+- MCP service added to Docker Compose stack
+- Full E2E and unit test suite for MCP server
+
+## [0.0.4] - 2026-03-01
+
+### Added
+- SKILL.md import/export with YAML frontmatter
+- Content versioning with set-latest and restore
+- Editor UX — sticky toolbar, raw SKILL.md frontmatter, version transition dialog
+- Comprehensive E2E tests for import flow
+
+### Fixed
+- Frontmatter duplication and version tracking bugs
+- Import race condition, title parsing, tag expansion
+
+## [0.0.3] - 2026-02-28
+
+### Added
+- Redesigned home page with editorial-style skill discovery
+- Redesigned skill detail page with hero header and field labels
+- User profile and created-by attribution on skills
+- Version info display in skill editor with save confirmation popup
+
+## [0.0.2] - 2026-02-27
+
+### Added
+- Full backend API — skills CRUD, comments, tags, content versioning
+- Offline-first state management with localStorage + API sync
+- Connection status banner for unconfigured/offline states
+- New Skill modal with keyboard shortcut (`N`)
+- Delete Skill with confirmation dialog
+- Docker Compose deployment (postgres, api, web)
+- CLI tool with agent adapters (Claude, Cursor, Codex, OpenHands)
+- Publish pipeline with bundle validation and checksummed ZIPs
+
+### Fixed
+- Comment visibility, swipe guard, auth/offline distinction
+
+## [0.0.1] - 2026-02-26
+
+### Added
+- Initial release — SkillNote self-hosted skill registry
+- Next.js frontend with App Router, Tailwind CSS, shadcn/ui
+- FastAPI backend with SQLAlchemy, Alembic migrations
+- PostgreSQL database with skill, version, and comment models
 - Dark/light theme with system default
+- Command palette with keyboard shortcuts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to SkillNote will be documented in this file.
+
+## [0.1.0] - 2026-03-08
+
+### Added
+- Skill registry with offline-first localStorage + PostgreSQL sync
+- SKILL.md import/export with YAML frontmatter
+- Content versioning with history, compare, and restore
+- MCP server for AI agent integration (Claude Code, Cursor, Codex, OpenHands)
+- Skill rating and completion tracking via `complete_skill` MCP tool
+- Analytics dashboard with usage trends and agent breakdowns
+- MCP Integrations page showing connected agents
+- Collections for organizing skills
+- Command palette with keyboard shortcuts
+- Settings page with MCP tool configuration
+- Docker Compose deployment (postgres, api, mcp, web)
+- CLI tool with agent adapters
+- Dark/light theme with system default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,14 +194,12 @@ App version is the single source of truth in `package.json` (`"version": "x.y.z"
 
 - **`next.config.ts`** reads `package.json` and exposes `NEXT_PUBLIC_APP_VERSION` at build time
 - **Sidebar footer** displays the version next to the connection status indicator
-- **Settings page** shows the version in the About section and a collapsible Changelog
-- **`CHANGELOG.md`** in the project root documents all releases
-- **`CHANGELOG_ENTRIES`** array in `src/app/(app)/settings/page.tsx` mirrors the changelog for in-app display
+- **Settings page** shows the version in the About section
+- **`CHANGELOG.md`** in the project root documents all releases (git-only, not shown in UI)
 
 When bumping the version:
 1. Update `"version"` in `package.json`
 2. Add a new entry to `CHANGELOG.md`
-3. Add a new entry to `CHANGELOG_ENTRIES` in `src/app/(app)/settings/page.tsx`
 
 ## SKILL.md Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,21 @@ Every save creates a `SkillContentVersion` snapshot (auto-incremented integer). 
 | `backend/app/validators/bundle_validator.py` | ZIP upload validation (path traversal, size limits, frontmatter) |
 | `backend/app/core/config.py` | All env vars with defaults |
 
+## Versioning
+
+App version is the single source of truth in `package.json` (`"version": "x.y.z"`).
+
+- **`next.config.ts`** reads `package.json` and exposes `NEXT_PUBLIC_APP_VERSION` at build time
+- **Sidebar footer** displays the version next to the connection status indicator
+- **Settings page** shows the version in the About section and a collapsible Changelog
+- **`CHANGELOG.md`** in the project root documents all releases
+- **`CHANGELOG_ENTRIES`** array in `src/app/(app)/settings/page.tsx` mirrors the changelog for in-app display
+
+When bumping the version:
+1. Update `"version"` in `package.json`
+2. Add a new entry to `CHANGELOG.md`
+3. Add a new entry to `CHANGELOG_ENTRIES` in `src/app/(app)/settings/page.tsx`
+
 ## SKILL.md Format
 
 ```markdown

--- a/backend/alembic/versions/0007_skill_ratings.py
+++ b/backend/alembic/versions/0007_skill_ratings.py
@@ -1,0 +1,37 @@
+"""add skill_ratings table
+
+Revision ID: 0007_skill_ratings
+Revises: 0006_analytics_events
+Create Date: 2026-03-08
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0007_skill_ratings'
+down_revision = '0006_analytics_events'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'skill_ratings',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('skill_slug', sa.Text(), nullable=False),
+        sa.Column('skill_version', sa.Integer(), nullable=False),
+        sa.Column('rating', sa.SmallInteger(), nullable=False),
+        sa.Column('outcome', sa.Text(), nullable=True),
+        sa.Column('agent_name', sa.Text(), nullable=True),
+        sa.Column('session_id', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint('rating >= 1 AND rating <= 5', name='ck_skill_ratings_rating_range'),
+    )
+    op.create_index('ix_skill_ratings_slug_created', 'skill_ratings', ['skill_slug', 'created_at'])
+    op.create_index('ix_skill_ratings_slug_version', 'skill_ratings', ['skill_slug', 'skill_version'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_skill_ratings_slug_version', table_name='skill_ratings')
+    op.drop_index('ix_skill_ratings_slug_created', table_name='skill_ratings')
+    op.drop_table('skill_ratings')

--- a/backend/alembic/versions/0008_settings_table.py
+++ b/backend/alembic/versions/0008_settings_table.py
@@ -1,0 +1,31 @@
+"""add settings table
+
+Revision ID: 0008_settings_table
+Revises: 0007_skill_ratings
+Create Date: 2026-03-08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0008_settings_table'
+down_revision = '0007_skill_ratings'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'settings',
+        sa.Column('key', sa.Text(), primary_key=True),
+        sa.Column('value', sa.Text(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.execute(
+        "INSERT INTO settings (key, value) VALUES "
+        "('complete_skill_enabled', 'true'), "
+        "('complete_skill_outcome_enabled', 'false')"
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('settings')

--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -216,6 +216,76 @@ def get_timeline(
     return result
 
 
+@router.get("/ratings")
+def get_ratings(
+    db: Session = Depends(get_db),
+):
+    """Aggregate ratings for all skills."""
+    rows = db.execute(
+        text("""
+            SELECT skill_slug AS slug,
+                   ROUND(AVG(rating)::numeric, 1) AS avg_rating,
+                   COUNT(*) AS rating_count
+            FROM skill_ratings
+            GROUP BY skill_slug
+            ORDER BY avg_rating DESC
+        """),
+    ).mappings().all()
+
+    return [
+        {
+            "slug": row["slug"],
+            "avg_rating": float(row["avg_rating"]),
+            "rating_count": row["rating_count"],
+        }
+        for row in rows
+    ]
+
+
+@router.get("/ratings/{skill_slug}")
+def get_rating_detail(
+    skill_slug: str,
+    db: Session = Depends(get_db),
+):
+    """Per-version rating breakdown for a single skill."""
+    overall = db.execute(
+        text("""
+            SELECT ROUND(AVG(rating)::numeric, 1) AS avg_rating,
+                   COUNT(*) AS rating_count
+            FROM skill_ratings
+            WHERE skill_slug = :slug
+        """),
+        {"slug": skill_slug},
+    ).mappings().one()
+
+    versions = db.execute(
+        text("""
+            SELECT skill_version AS version,
+                   ROUND(AVG(rating)::numeric, 1) AS avg_rating,
+                   COUNT(*) AS rating_count
+            FROM skill_ratings
+            WHERE skill_slug = :slug
+            GROUP BY skill_version
+            ORDER BY skill_version DESC
+        """),
+        {"slug": skill_slug},
+    ).mappings().all()
+
+    return {
+        "slug": skill_slug,
+        "avg_rating": float(overall["avg_rating"]) if overall["avg_rating"] else None,
+        "rating_count": overall["rating_count"],
+        "versions": [
+            {
+                "version": v["version"],
+                "avg_rating": float(v["avg_rating"]),
+                "rating_count": v["rating_count"],
+            }
+            for v in versions
+        ],
+    }
+
+
 @router.get("/collections")
 def get_collections(
     days: int = Query(default=7, ge=0),

--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -286,6 +286,146 @@ def get_rating_detail(
     }
 
 
+@router.get("/top-skills")
+def get_top_skills(
+    days: int = Query(default=30, ge=0),
+    limit: int = Query(default=10, ge=1, le=50),
+    db: Session = Depends(get_db),
+):
+    """Top skills ranked by a composite score: calls + rating quality.
+
+    Returns call count, avg rating, rating count, and completion rate
+    (how often agents rate after using a skill).
+    """
+    date_clause = _date_filter_clause(days, alias="e.created_at")
+
+    rows = db.execute(
+        text(f"""
+            WITH calls AS (
+                SELECT skill_slug AS slug,
+                       COUNT(*) AS call_count,
+                       MAX(created_at) AS last_called_at
+                FROM skill_call_events
+                WHERE skill_slug IS NOT NULL
+                {date_clause}
+                GROUP BY skill_slug
+            ),
+            ratings AS (
+                SELECT skill_slug AS slug,
+                       ROUND(AVG(rating)::numeric, 1) AS avg_rating,
+                       COUNT(*) AS rating_count
+                FROM skill_ratings
+                WHERE 1=1
+                {_date_filter_clause(days, alias="created_at")}
+                GROUP BY skill_slug
+            )
+            SELECT c.slug,
+                   c.call_count,
+                   c.last_called_at,
+                   COALESCE(r.avg_rating, 0) AS avg_rating,
+                   COALESCE(r.rating_count, 0) AS rating_count,
+                   CASE WHEN c.call_count > 0
+                        THEN ROUND(COALESCE(r.rating_count, 0)::numeric / c.call_count * 100, 1)
+                        ELSE 0 END AS completion_rate
+            FROM calls c
+            LEFT JOIN ratings r ON c.slug = r.slug
+            ORDER BY c.call_count DESC, COALESCE(r.avg_rating, 0) DESC
+            LIMIT :limit
+        """),
+        {**_build_params(days, None, None), "limit": limit},
+    ).mappings().all()
+
+    return [
+        {
+            "slug": row["slug"],
+            "call_count": row["call_count"],
+            "last_called_at": row["last_called_at"].isoformat() if row["last_called_at"] else None,
+            "avg_rating": float(row["avg_rating"]) if row["avg_rating"] else None,
+            "rating_count": row["rating_count"],
+            "completion_rate": float(row["completion_rate"]),
+        }
+        for row in rows
+    ]
+
+
+@router.get("/rating-summary")
+def get_rating_summary(
+    days: int = Query(default=30, ge=0),
+    db: Session = Depends(get_db),
+):
+    """Overall rating stats across all skills."""
+    date_clause = _date_filter_clause(days)
+
+    row = db.execute(
+        text(f"""
+            SELECT COUNT(*) AS total_ratings,
+                   ROUND(AVG(rating)::numeric, 1) AS overall_avg,
+                   COUNT(DISTINCT skill_slug) AS rated_skills,
+                   COUNT(DISTINCT agent_name) FILTER (WHERE agent_name != '') AS rating_agents
+            FROM skill_ratings
+            WHERE 1=1
+            {date_clause}
+        """),
+        _build_params(days, None, None),
+    ).mappings().one()
+
+    # Rating distribution (1-5)
+    dist_rows = db.execute(
+        text(f"""
+            SELECT rating, COUNT(*) AS count
+            FROM skill_ratings
+            WHERE 1=1
+            {date_clause}
+            GROUP BY rating
+            ORDER BY rating
+        """),
+        _build_params(days, None, None),
+    ).mappings().all()
+
+    distribution = {r: 0 for r in range(1, 6)}
+    for dr in dist_rows:
+        distribution[dr["rating"]] = dr["count"]
+
+    return {
+        "total_ratings": row["total_ratings"],
+        "overall_avg": float(row["overall_avg"]) if row["overall_avg"] else None,
+        "rated_skills": row["rated_skills"],
+        "rating_agents": row["rating_agents"],
+        "distribution": distribution,
+    }
+
+
+@router.get("/ratings/{skill_slug}/reviews")
+def get_skill_reviews(
+    skill_slug: str,
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
+    """Individual rating reviews for a skill, newest first."""
+    rows = db.execute(
+        text("""
+            SELECT id, rating, outcome, agent_name, skill_version, session_id, created_at
+            FROM skill_ratings
+            WHERE skill_slug = :slug
+            ORDER BY created_at DESC
+            LIMIT :limit
+        """),
+        {"slug": skill_slug, "limit": limit},
+    ).mappings().all()
+
+    return [
+        {
+            "id": str(row["id"]),
+            "rating": row["rating"],
+            "outcome": row["outcome"],
+            "agent_name": row["agent_name"] or "unknown",
+            "skill_version": row["skill_version"],
+            "created_at": row["created_at"].isoformat() if row["created_at"] else None,
+        }
+        for row in rows
+    ]
+
+
 @router.get("/collections")
 def get_collections(
     days: int = Query(default=7, ge=0),

--- a/backend/app/api/settings.py
+++ b/backend/app/api/settings.py
@@ -1,0 +1,50 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+
+router = APIRouter(prefix="/v1/settings", tags=["settings"])
+
+# Allowlist of known settings and their valid values
+_VALID_SETTINGS: dict[str, set[str]] = {
+    "complete_skill_enabled": {"true", "false"},
+    "complete_skill_outcome_enabled": {"true", "false"},
+}
+
+
+@router.get("")
+def get_settings(db: Session = Depends(get_db)):
+    rows = db.execute(text("SELECT key, value FROM settings")).mappings().all()
+    return {row["key"]: row["value"] for row in rows}
+
+
+@router.put("")
+def update_settings(patch: dict[str, str], db: Session = Depends(get_db)):
+    for key, value in patch.items():
+        if key not in _VALID_SETTINGS:
+            raise HTTPException(
+                status_code=422,
+                detail={"code": "INVALID_SETTING", "message": f"Unknown setting: {key}"},
+            )
+        if value not in _VALID_SETTINGS[key]:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "code": "INVALID_VALUE",
+                    "message": f"Invalid value for {key}: must be one of {sorted(_VALID_SETTINGS[key])}",
+                },
+            )
+
+    for key, value in patch.items():
+        db.execute(
+            text(
+                "INSERT INTO settings (key, value, updated_at) "
+                "VALUES (:key, :value, now()) "
+                "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()"
+            ),
+            {"key": key, "value": value},
+        )
+    db.execute(text("SELECT pg_notify('skillnote_skills_changed', 'settings')"))
+    db.commit()
+    return {"status": "ok"}

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -2,6 +2,7 @@ from app.db.models.analytics_event import AnalyticsEvent
 from app.db.models.comment import Comment
 from app.db.models.skill import Skill
 from app.db.models.skill_content_version import SkillContentVersion
+from app.db.models.skill_rating import SkillRating
 from app.db.models.skill_version import SkillVersion
 
-__all__ = ["Skill", "SkillVersion", "SkillContentVersion", "Comment", "AnalyticsEvent"]
+__all__ = ["Skill", "SkillVersion", "SkillContentVersion", "Comment", "AnalyticsEvent", "SkillRating"]

--- a/backend/app/db/models/skill_rating.py
+++ b/backend/app/db/models/skill_rating.py
@@ -1,0 +1,24 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Integer, SmallInteger, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class SkillRating(Base):
+    __tablename__ = "skill_ratings"
+    __table_args__ = (
+        CheckConstraint("rating >= 1 AND rating <= 5", name="ck_skill_ratings_rating_range"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    skill_slug: Mapped[str] = mapped_column(Text, nullable=False)
+    skill_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    rating: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    outcome: Mapped[str | None] = mapped_column(Text, nullable=True)
+    agent_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    session_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.skills import router as skills_router
 from app.api.downloads import router as downloads_router
 from app.api.publish import router as publish_router
 from app.api.comments import router as comments_router
+from app.api.settings import router as settings_router
 
 app = FastAPI(title="SkillNote Backend", version="0.1.0")
 
@@ -48,6 +49,7 @@ app.include_router(downloads_router)
 app.include_router(publish_router)
 app.include_router(comments_router)
 app.include_router(analytics_router)
+app.include_router(settings_router)
 
 
 @app.get("/health")

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -163,6 +163,9 @@ async def _pg_listen_loop() -> None:
                         "Received NOTIFY: channel=%s payload=%r",
                         notify.channel, notify.payload,
                     )
+                    # Refresh instructions in case settings changed
+                    if notify.payload == "settings":
+                        await asyncio.to_thread(_refresh_mcp_instructions)
                     asyncio.create_task(
                         broadcast_tools_changed(),
                         name="broadcast-tools-changed",
@@ -353,19 +356,43 @@ engine = create_engine(
 )
 
 
+_SETTINGS_DEFAULTS = {"complete_skill_enabled": "true", "complete_skill_outcome_enabled": "false"}
+
+
+def _read_settings_sync(db_engine=None) -> dict[str, str]:
+    """Read all settings from the database. Returns dict of key->value.
+
+    Falls back to safe defaults if the database is unreachable (e.g. during
+    startup before migrations have run, or in test environments).
+    """
+    try:
+        with Session(db_engine or engine) as db:
+            rows = db.execute(text("SELECT key, value FROM settings")).mappings().all()
+            return {row["key"]: row["value"] for row in rows}
+    except Exception:
+        logger.exception("Failed to read settings, using defaults")
+        return dict(_SETTINGS_DEFAULTS)
+
+
 class SkillTool(Tool):
     """A tool that returns SKILL.md content for a specific skill."""
 
     skill_slug: str
     content_md: str
     skill_name: str
+    complete_skill_enabled: bool = True
+    complete_skill_outcome_enabled: bool = False
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
-        return ToolResult(
-            content=f"# {self.skill_name}\n\n{self.content_md}"
-                    f"\n\n---\n_When you're done applying this skill, close the loop:_\n"
-                    f"`complete_skill(skill_slug=\"{self.skill_slug}\", rating=<1-5>, outcome=\"what you did\")`"
-        )
+        safe_slug = self.skill_slug.replace('"', '\\"').replace('`', '')
+        content = f"# {self.skill_name}\n\n{self.content_md}"
+        if self.complete_skill_enabled:
+            if self.complete_skill_outcome_enabled:
+                hint = f'`complete_skill(skill_slug="{safe_slug}", rating=<1-5>, outcome="what you did")`'
+            else:
+                hint = f'`complete_skill(skill_slug="{safe_slug}", rating=<1-5>)`'
+            content += f"\n\n---\n_When you're done applying this skill, close the loop:_\n{hint}"
+        return ToolResult(content=content)
 
 
 class SkillNoteToolProvider(Provider):
@@ -428,7 +455,9 @@ class SkillNoteToolProvider(Provider):
             logger.exception("DB error fetching skills (slug=%r)", slug)
             raise
 
-    def _to_tool(self, skill: dict) -> SkillTool:
+    def _to_tool(self, skill: dict, settings: dict[str, str]) -> SkillTool:
+        cs_enabled = settings.get("complete_skill_enabled", "true") == "true"
+        outcome_enabled = settings.get("complete_skill_outcome_enabled", "false") == "true"
         return SkillTool(
             name=skill["slug"],
             description=skill["description"] or "",
@@ -436,15 +465,57 @@ class SkillNoteToolProvider(Provider):
             skill_slug=skill["slug"],
             skill_name=skill["name"],
             content_md=skill["content_md"] or "",
+            complete_skill_enabled=cs_enabled,
+            complete_skill_outcome_enabled=outcome_enabled,
         )
 
+    def _make_complete_skill_tool(self, settings: dict[str, str]) -> "CompleteSkillTool":
+        """Build the complete_skill Tool dynamically based on settings."""
+        outcome_enabled = settings.get("complete_skill_outcome_enabled", "false") == "true"
+        properties: dict[str, Any] = {
+            "skill_slug": {"type": "string", "description": "The slug of the skill you used."},
+            "rating": {"type": "integer", "description": "Your rating from 1 (unhelpful) to 5 (excellent)."},
+        }
+        required = ["skill_slug", "rating"]
+        if outcome_enabled:
+            properties["outcome"] = {
+                "type": "string",
+                "default": "",
+                "description": "Brief description of what you accomplished with the skill.",
+            }
+
+        return CompleteSkillTool(
+            name="complete_skill",
+            description="Complete a skill session after applying it. Rate 1-5 and describe what you did.\n\nArgs:\n    skill_slug: The slug of the skill you used.\n    rating: Your rating from 1 (unhelpful) to 5 (excellent)."
+                + ("\n    outcome: Brief description of what you accomplished with the skill." if outcome_enabled else ""),
+            parameters={
+                "type": "object",
+                "properties": properties,
+                "required": required,
+            },
+        )
+
+    def _read_settings(self) -> dict[str, str]:
+        return _read_settings_sync(self.engine)
+
     async def _list_tools(self) -> Sequence[Tool]:
-        skills = await asyncio.to_thread(self._fetch_skills)
-        return [self._to_tool(s) for s in skills]
+        skills, settings = await asyncio.gather(
+            asyncio.to_thread(self._fetch_skills),
+            asyncio.to_thread(self._read_settings),
+        )
+        tools: list[Tool] = [self._to_tool(s, settings) for s in skills]
+        if settings.get("complete_skill_enabled", "true") == "true":
+            tools.append(self._make_complete_skill_tool(settings))
+        return tools
 
     async def _get_tool(self, name: str, version=None) -> Tool | None:
+        settings = await asyncio.to_thread(self._read_settings)
+        if name == "complete_skill":
+            if settings.get("complete_skill_enabled", "true") == "true":
+                return self._make_complete_skill_tool(settings)
+            return None
         skills = await asyncio.to_thread(self._fetch_skills, name)
-        return self._to_tool(skills[0]) if skills else None
+        return self._to_tool(skills[0], settings) if skills else None
 
 
 def _log_event_sync(skill_slug: str, agent_name: str, agent_version: str,
@@ -482,22 +553,29 @@ async def _log_event(skill_slug: str, session_meta: dict | None, scope: str | No
     await asyncio.to_thread(_log_event_sync, skill_slug, agent_name, agent_version, session_id, scope, remote)
 
 
-def _get_skill_version_sync(slug: str) -> int | None:
-    """Look up current_version for a skill by slug. Returns None if not found."""
+def _get_skill_version_sync(slug: str) -> tuple[int | None, str | None]:
+    """Look up current_version for a skill by slug.
+
+    Returns (version, None) on success, (None, None) if not found,
+    or (None, error_msg) on database error.
+    """
     try:
         with Session(engine) as db:
             row = db.execute(
                 text("SELECT current_version FROM skills WHERE slug = :slug"),
                 {"slug": slug},
             ).mappings().first()
-            return row["current_version"] if row else None
+            if row:
+                return row["current_version"], None
+            return None, None
     except Exception:
         logger.exception("Failed to look up skill version for %r", slug)
-        return None
+        return None, "database error"
 
 
 def _insert_rating_sync(slug: str, version: int, rating: int, outcome: str | None,
-                         agent_name: str, session_id: str) -> None:
+                         agent_name: str, session_id: str) -> str | None:
+    """Insert a rating row. Returns None on success, error message on failure."""
     import uuid as _uuid
     try:
         with Session(engine) as db:
@@ -516,8 +594,10 @@ def _insert_rating_sync(slug: str, version: int, rating: int, outcome: str | Non
                 }
             )
             db.commit()
+            return None
     except Exception:
         logger.exception("Failed to insert skill rating")
+        return "failed to save rating"
 
 
 def _resolve_session_meta() -> dict | None:
@@ -529,16 +609,40 @@ def _resolve_session_meta() -> dict | None:
 
 provider = SkillNoteToolProvider(db_engine=engine)
 
+_INSTRUCTIONS_WITH_COMPLETE = (
+    "This server provides AI skills from a SkillNote registry. "
+    "Each tool represents a skill — call it when the user's task matches its description. "
+    "The tool returns detailed instructions you should follow. "
+    "After using a skill, check if other available skills might also help with the task. "
+    "IMPORTANT: After applying a skill and seeing the results, always call `complete_skill` "
+    "with a rating (1-5) and a brief outcome describing what you did."
+)
+
+_INSTRUCTIONS_WITHOUT_COMPLETE = (
+    "This server provides AI skills from a SkillNote registry. "
+    "Each tool represents a skill — call it when the user's task matches its description. "
+    "The tool returns detailed instructions you should follow. "
+    "After using a skill, check if other available skills might also help with the task."
+)
+
+
+def _refresh_mcp_instructions() -> None:
+    """Update the MCP server instructions based on current settings.
+
+    Called on startup and whenever settings change (via pg_notify).
+    Only affects newly initializing sessions; already-connected clients
+    received instructions during their own initialization handshake.
+    """
+    settings = _read_settings_sync()
+    cs_enabled = settings.get("complete_skill_enabled", "true") == "true"
+    mcp.instructions = (
+        _INSTRUCTIONS_WITH_COMPLETE if cs_enabled else _INSTRUCTIONS_WITHOUT_COMPLETE
+    )
+
+
 mcp = FastMCP(
     name="SkillNote",
-    instructions=(
-        "This server provides AI skills from a SkillNote registry. "
-        "Each tool represents a skill — call it when the user's task matches its description. "
-        "The tool returns detailed instructions you should follow. "
-        "After using a skill, check if other available skills might also help with the task. "
-        "IMPORTANT: After applying a skill and seeing the results, always call `complete_skill` "
-        "with a rating (1-5) and a brief outcome describing what you did."
-    ),
+    instructions=_INSTRUCTIONS_WITH_COMPLETE,  # default; refreshed on startup
     providers=[provider],
 )
 
@@ -547,32 +651,37 @@ mcp = FastMCP(
 mcp.add_middleware(SessionCapturingMiddleware())
 
 
-@mcp.tool()
-async def complete_skill(skill_slug: str, rating: int, outcome: str = "") -> str:
-    """Complete a skill session after applying it. Rate 1-5 and describe what you did.
+class CompleteSkillTool(Tool):
+    """Tool that records a skill rating from an AI agent."""
 
-    Args:
-        skill_slug: The slug of the skill you used.
-        rating: Your rating from 1 (unhelpful) to 5 (excellent).
-        outcome: Brief description of what you accomplished with the skill.
-    """
-    if rating < 1 or rating > 5:
-        return "Error: rating must be between 1 and 5."
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        skill_slug = arguments.get("skill_slug", "")
+        rating = arguments.get("rating", 0)
+        outcome = arguments.get("outcome", "")
 
-    version = await asyncio.to_thread(_get_skill_version_sync, skill_slug)
-    if version is None:
-        return f"Error: skill '{skill_slug}' not found."
+        if not isinstance(rating, int) or rating < 1 or rating > 5:
+            return ToolResult(content="Error: rating must be an integer between 1 and 5.")
 
-    session_meta = _resolve_session_meta()
-    agent_name = session_meta.get("client_name", "") if session_meta else ""
-    session_id = session_meta.get("id", "") if session_meta else ""
+        outcome_trimmed = (outcome or "")[:2000] or None
 
-    await asyncio.to_thread(
-        _insert_rating_sync, skill_slug, version, rating,
-        outcome or None, agent_name, session_id,
-    )
+        version, db_err = await asyncio.to_thread(_get_skill_version_sync, skill_slug)
+        if db_err:
+            return ToolResult(content="Error: could not look up skill (database unavailable). Try again later.")
+        if version is None:
+            return ToolResult(content=f"Error: skill '{skill_slug}' not found.")
 
-    return f"Completed '{skill_slug}' (v{version}): {rating}/5. Thank you for the feedback!"
+        session_meta = _resolve_session_meta()
+        agent_name = session_meta.get("client_name", "") if session_meta else ""
+        session_id = session_meta.get("id", "") if session_meta else ""
+
+        insert_err = await asyncio.to_thread(
+            _insert_rating_sync, skill_slug, version, rating,
+            outcome_trimmed, agent_name, session_id,
+        )
+        if insert_err:
+            return ToolResult(content="Error: rating received but could not be saved. Try again later.")
+
+        return ToolResult(content=f"Completed '{skill_slug}' (v{version}): {rating}/5. Thank you for the feedback!")
 
 
 @mcp.custom_route("/status", methods=["GET"])
@@ -617,6 +726,8 @@ if __name__ == "__main__":
 
     @_acm
     async def _lifespan_with_pg(app):
+        # Refresh instructions from DB now that the server is starting up
+        await asyncio.to_thread(_refresh_mcp_instructions)
         pg_task = asyncio.create_task(_pg_listen_loop(), name="pg-listener")
         try:
             async with _original_lifespan(app):

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -361,7 +361,11 @@ class SkillTool(Tool):
     skill_name: str
 
     async def run(self, arguments: dict[str, Any]) -> ToolResult:
-        return ToolResult(content=f"# {self.skill_name}\n\n{self.content_md}")
+        return ToolResult(
+            content=f"# {self.skill_name}\n\n{self.content_md}"
+                    f"\n\n---\n_When you're done applying this skill, close the loop:_\n"
+                    f"`complete_skill(skill_slug=\"{self.skill_slug}\", rating=<1-5>, outcome=\"what you did\")`"
+        )
 
 
 class SkillNoteToolProvider(Provider):
@@ -478,6 +482,51 @@ async def _log_event(skill_slug: str, session_meta: dict | None, scope: str | No
     await asyncio.to_thread(_log_event_sync, skill_slug, agent_name, agent_version, session_id, scope, remote)
 
 
+def _get_skill_version_sync(slug: str) -> int | None:
+    """Look up current_version for a skill by slug. Returns None if not found."""
+    try:
+        with Session(engine) as db:
+            row = db.execute(
+                text("SELECT current_version FROM skills WHERE slug = :slug"),
+                {"slug": slug},
+            ).mappings().first()
+            return row["current_version"] if row else None
+    except Exception:
+        logger.exception("Failed to look up skill version for %r", slug)
+        return None
+
+
+def _insert_rating_sync(slug: str, version: int, rating: int, outcome: str | None,
+                         agent_name: str, session_id: str) -> None:
+    import uuid as _uuid
+    try:
+        with Session(engine) as db:
+            db.execute(
+                text("""INSERT INTO skill_ratings
+                    (id, skill_slug, skill_version, rating, outcome, agent_name, session_id)
+                    VALUES (:id, :slug, :version, :rating, :outcome, :agent, :session)"""),
+                {
+                    "id": str(_uuid.uuid4()),
+                    "slug": slug,
+                    "version": version,
+                    "rating": rating,
+                    "outcome": outcome,
+                    "agent": agent_name,
+                    "session": session_id,
+                }
+            )
+            db.commit()
+    except Exception:
+        logger.exception("Failed to insert skill rating")
+
+
+def _resolve_session_meta() -> dict | None:
+    """Pick the most recently seen active connection (same heuristic as analytics)."""
+    if not _active_connections:
+        return None
+    return max(_active_connections.values(), key=lambda s: s.get("last_seen", 0))
+
+
 provider = SkillNoteToolProvider(db_engine=engine)
 
 mcp = FastMCP(
@@ -486,7 +535,9 @@ mcp = FastMCP(
         "This server provides AI skills from a SkillNote registry. "
         "Each tool represents a skill — call it when the user's task matches its description. "
         "The tool returns detailed instructions you should follow. "
-        "After using a skill, check if other available skills might also help with the task."
+        "After using a skill, check if other available skills might also help with the task. "
+        "IMPORTANT: After applying a skill and seeing the results, always call `complete_skill` "
+        "with a rating (1-5) and a brief outcome describing what you did."
     ),
     providers=[provider],
 )
@@ -494,6 +545,34 @@ mcp = FastMCP(
 # Register the session-capturing middleware so every initialized session is
 # stored in _session_registry and can receive tool-change notifications.
 mcp.add_middleware(SessionCapturingMiddleware())
+
+
+@mcp.tool()
+async def complete_skill(skill_slug: str, rating: int, outcome: str = "") -> str:
+    """Complete a skill session after applying it. Rate 1-5 and describe what you did.
+
+    Args:
+        skill_slug: The slug of the skill you used.
+        rating: Your rating from 1 (unhelpful) to 5 (excellent).
+        outcome: Brief description of what you accomplished with the skill.
+    """
+    if rating < 1 or rating > 5:
+        return "Error: rating must be between 1 and 5."
+
+    version = await asyncio.to_thread(_get_skill_version_sync, skill_slug)
+    if version is None:
+        return f"Error: skill '{skill_slug}' not found."
+
+    session_meta = _resolve_session_meta()
+    agent_name = session_meta.get("client_name", "") if session_meta else ""
+    session_id = session_meta.get("id", "") if session_meta else ""
+
+    await asyncio.to_thread(
+        _insert_rating_sync, skill_slug, version, rating,
+        outcome or None, agent_name, session_id,
+    )
+
+    return f"Completed '{skill_slug}' (v{version}): {rating}/5. Thank you for the feedback!"
 
 
 @mcp.custom_route("/status", methods=["GET"])

--- a/backend/tests/unit/test_mcp_server.py
+++ b/backend/tests/unit/test_mcp_server.py
@@ -315,7 +315,7 @@ class TestSkillToolRun:
         )
         result = asyncio.get_event_loop().run_until_complete(tool.run({}))
         text = result.content[0].text if hasattr(result.content[0], "text") else str(result.content[0])
-        assert text == "# S\n\n"
+        assert text.startswith("# S\n\n")
 
     def test_run_ignores_extra_arguments(self):
         """SkillTool takes no params; extra arguments must be silently ignored."""

--- a/backend/tests/unit/test_mcp_server.py
+++ b/backend/tests/unit/test_mcp_server.py
@@ -161,6 +161,9 @@ class TestParseFilters:
 # _to_tool
 # ---------------------------------------------------------------------------
 
+DEFAULT_SETTINGS = {"complete_skill_enabled": "true", "complete_skill_outcome_enabled": "false"}
+
+
 class TestToTool:
     def setup_method(self):
         from mcp_server import SkillNoteToolProvider
@@ -169,7 +172,7 @@ class TestToTool:
     def test_basic_mapping(self):
         skill = {"slug": "my-skill", "name": "My Skill",
                  "description": "A skill", "content_md": "## Hello"}
-        tool = self.p._to_tool(skill)
+        tool = self.p._to_tool(skill, DEFAULT_SETTINGS)
         assert tool.name == "my-skill"
         assert tool.description == "A skill"
         assert tool.skill_name == "My Skill"
@@ -177,28 +180,28 @@ class TestToTool:
 
     def test_null_content_md_becomes_empty_string(self):
         skill = {"slug": "s", "name": "S", "description": "d", "content_md": None}
-        tool = self.p._to_tool(skill)
+        tool = self.p._to_tool(skill, DEFAULT_SETTINGS)
         assert tool.content_md == ""
 
     def test_null_description_becomes_empty_string(self):
         skill = {"slug": "s", "name": "S", "description": None, "content_md": "x"}
-        tool = self.p._to_tool(skill)
+        tool = self.p._to_tool(skill, DEFAULT_SETTINGS)
         assert tool.description == ""
 
     def test_empty_string_content_md_preserved(self):
         skill = {"slug": "s", "name": "S", "description": "d", "content_md": ""}
-        tool = self.p._to_tool(skill)
+        tool = self.p._to_tool(skill, DEFAULT_SETTINGS)
         assert tool.content_md == ""
 
     def test_parameters_schema_is_empty_object(self):
         skill = {"slug": "s", "name": "S", "description": "d", "content_md": "x"}
-        tool = self.p._to_tool(skill)
+        tool = self.p._to_tool(skill, DEFAULT_SETTINGS)
         assert tool.parameters == {"type": "object", "properties": {}}
 
     def test_slug_used_as_tool_name_not_human_name(self):
         skill = {"slug": "the-slug", "name": "Human Name",
                  "description": "d", "content_md": "x"}
-        tool = self.p._to_tool(skill)
+        tool = self.p._to_tool(skill, DEFAULT_SETTINGS)
         assert tool.name == "the-slug"
         assert tool.skill_name == "Human Name"
 
@@ -353,24 +356,31 @@ class TestAsyncProviderMethods:
     def _run(self, coro):
         return asyncio.get_event_loop().run_until_complete(coro)
 
-    def test_list_tools_empty_db(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_list_tools_empty_db(self, _):
         self.provider._fetch_skills = MagicMock(return_value=[])
         tools = self._run(self.provider._list_tools())
-        assert tools == []
+        # Should have only complete_skill when DB has no skills
+        assert len(tools) == 1
+        assert tools[0].name == "complete_skill"
 
-    def test_list_tools_returns_all_skills(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_list_tools_returns_all_skills(self, _):
         self.provider._fetch_skills = MagicMock(return_value=SAMPLE_SKILLS)
         tools = self._run(self.provider._list_tools())
         names = [t.name for t in tools]
         assert "alpha" in names
         assert "beta" in names
+        assert "complete_skill" in names
 
-    def test_list_tools_calls_fetch_with_no_slug(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_list_tools_calls_fetch_with_no_slug(self, _):
         self.provider._fetch_skills = MagicMock(return_value=[])
         self._run(self.provider._list_tools())
         self.provider._fetch_skills.assert_called_once_with()
 
-    def test_get_tool_returns_correct_skill(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_get_tool_returns_correct_skill(self, _):
         target = [{"slug": "target", "name": "Target Skill",
                    "description": "d", "content_md": "## hi"}]
         self.provider._fetch_skills = MagicMock(return_value=target)
@@ -380,12 +390,14 @@ class TestAsyncProviderMethods:
         assert tool.skill_name == "Target Skill"
         self.provider._fetch_skills.assert_called_once_with("target")
 
-    def test_get_tool_returns_none_for_missing_slug(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_get_tool_returns_none_for_missing_slug(self, _):
         self.provider._fetch_skills = MagicMock(return_value=[])
         tool = self._run(self.provider._get_tool("missing"))
         assert tool is None
 
-    def test_get_tool_empty_string_fetch_called_with_empty_string(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_get_tool_empty_string_fetch_called_with_empty_string(self, _):
         """Regression: _get_tool('') must call _fetch_skills('') (not _fetch_skills(None))
         so the empty-slug WHERE clause is triggered and no rows are returned."""
         self.provider._fetch_skills = MagicMock(return_value=[])
@@ -394,18 +406,54 @@ class TestAsyncProviderMethods:
         self.provider._fetch_skills.assert_called_once_with("")
         assert tool is None
 
-    def test_get_tool_none_returns_none(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_get_tool_none_returns_none(self, _):
         self.provider._fetch_skills = MagicMock(return_value=[])
         tool = self._run(self.provider._get_tool(None))
         assert tool is None
 
-    def test_list_tools_converts_all_rows_to_skill_tools(self):
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_list_tools_converts_all_rows_to_skill_tools(self, _):
         self.provider._fetch_skills = MagicMock(return_value=SAMPLE_SKILLS)
         tools = self._run(self.provider._list_tools())
-        assert len(tools) == 2
+        # 2 skill tools + 1 complete_skill tool
+        assert len(tools) == 3
         from mcp_server import SkillTool
-        for t in tools:
-            assert isinstance(t, SkillTool)
+        skill_tools = [t for t in tools if isinstance(t, SkillTool)]
+        assert len(skill_tools) == 2
+
+    @patch("mcp_server._read_settings_sync", return_value={"complete_skill_enabled": "false", "complete_skill_outcome_enabled": "false"})
+    def test_list_tools_excludes_complete_skill_when_disabled(self, _):
+        self.provider._fetch_skills = MagicMock(return_value=SAMPLE_SKILLS)
+        tools = self._run(self.provider._list_tools())
+        names = [t.name for t in tools]
+        assert "complete_skill" not in names
+        assert len(tools) == 2
+
+    @patch("mcp_server._read_settings_sync", return_value={"complete_skill_enabled": "true", "complete_skill_outcome_enabled": "true"})
+    def test_complete_skill_tool_includes_outcome_when_enabled(self, _):
+        self.provider._fetch_skills = MagicMock(return_value=[])
+        tools = self._run(self.provider._list_tools())
+        cs_tool = [t for t in tools if t.name == "complete_skill"][0]
+        assert "outcome" in cs_tool.parameters["properties"]
+
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_complete_skill_tool_omits_outcome_when_disabled(self, _):
+        self.provider._fetch_skills = MagicMock(return_value=[])
+        tools = self._run(self.provider._list_tools())
+        cs_tool = [t for t in tools if t.name == "complete_skill"][0]
+        assert "outcome" not in cs_tool.parameters["properties"]
+
+    @patch("mcp_server._read_settings_sync", return_value={"complete_skill_enabled": "false"})
+    def test_get_tool_complete_skill_returns_none_when_disabled(self, _):
+        tool = self._run(self.provider._get_tool("complete_skill"))
+        assert tool is None
+
+    @patch("mcp_server._read_settings_sync", return_value=DEFAULT_SETTINGS)
+    def test_get_tool_complete_skill_returns_tool_when_enabled(self, _):
+        tool = self._run(self.provider._get_tool("complete_skill"))
+        assert tool is not None
+        assert tool.name == "complete_skill"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_settings_api.py
+++ b/backend/tests/unit/test_settings_api.py
@@ -1,0 +1,51 @@
+"""Unit tests for the settings API validation constants.
+
+Imports the allowlist directly to avoid requiring fastapi in the test env.
+"""
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+
+def _import_valid_settings():
+    """Import _VALID_SETTINGS without triggering FastAPI dependency."""
+    # Create mock modules for fastapi imports
+    fastapi_mock = MagicMock()
+    fastapi_mock.APIRouter = MagicMock(return_value=MagicMock(get=MagicMock(), put=MagicMock()))
+    fastapi_mock.Depends = MagicMock()
+    fastapi_mock.HTTPException = Exception
+
+    saved = {}
+    for mod_name in ("fastapi", "app.db.session"):
+        if mod_name in sys.modules:
+            saved[mod_name] = sys.modules[mod_name]
+        sys.modules[mod_name] = fastapi_mock
+
+    try:
+        if "app.api.settings" in sys.modules:
+            del sys.modules["app.api.settings"]
+        from app.api.settings import _VALID_SETTINGS
+        return _VALID_SETTINGS
+    finally:
+        for mod_name, original in saved.items():
+            sys.modules[mod_name] = original
+        for mod_name in ("fastapi", "app.db.session"):
+            if mod_name not in saved:
+                sys.modules.pop(mod_name, None)
+        sys.modules.pop("app.api.settings", None)
+
+
+class TestSettingsValidation:
+    def test_known_settings_all_boolean(self):
+        valid = _import_valid_settings()
+        for key, valid_values in valid.items():
+            assert valid_values == {"true", "false"}, f"{key} should accept true/false"
+
+    def test_expected_keys_present(self):
+        valid = _import_valid_settings()
+        assert "complete_skill_enabled" in valid
+        assert "complete_skill_outcome_enabled" in valid
+
+    def test_no_unexpected_keys(self):
+        valid = _import_valid_settings()
+        assert len(valid) == 2

--- a/backend/tests/unit/test_skill_ratings.py
+++ b/backend/tests/unit/test_skill_ratings.py
@@ -1,56 +1,93 @@
-"""Unit tests for the complete_skill MCP tool and rating helpers."""
+"""Unit tests for the CompleteSkillTool and rating helpers."""
 import asyncio
 
 import pytest
 from unittest.mock import patch
 
 
+def _run_complete_skill(skill_slug, rating, outcome=""):
+    """Helper: instantiate CompleteSkillTool and run it with given arguments."""
+    from mcp_server import CompleteSkillTool
+    tool = CompleteSkillTool(
+        name="complete_skill",
+        description="test",
+        parameters={"type": "object", "properties": {}},
+    )
+    arguments = {"skill_slug": skill_slug, "rating": rating}
+    if outcome:
+        arguments["outcome"] = outcome
+    result = asyncio.get_event_loop().run_until_complete(tool.run(arguments))
+    return result.content[0].text if hasattr(result.content[0], "text") else str(result.content[0])
+
+
 class TestCompleteSkillValidation:
     """Test rating validation logic."""
 
     def test_rating_below_range(self):
-        from mcp_server import complete_skill
-        result = asyncio.get_event_loop().run_until_complete(complete_skill("test-skill", 0))
+        result = _run_complete_skill("test-skill", 0)
         assert "Error" in result
         assert "between 1 and 5" in result
 
     def test_rating_above_range(self):
-        from mcp_server import complete_skill
-        result = asyncio.get_event_loop().run_until_complete(complete_skill("test-skill", 6))
+        result = _run_complete_skill("test-skill", 6)
+        assert "Error" in result
+        assert "between 1 and 5" in result
+
+    def test_rating_not_int(self):
+        result = _run_complete_skill("test-skill", 3.5)
         assert "Error" in result
         assert "between 1 and 5" in result
 
     def test_nonexistent_skill(self):
-        from mcp_server import complete_skill
-        with patch("mcp_server._get_skill_version_sync", return_value=None):
-            result = asyncio.get_event_loop().run_until_complete(complete_skill("nonexistent", 4))
+        with patch("mcp_server._get_skill_version_sync", return_value=(None, None)):
+            result = _run_complete_skill("nonexistent", 4)
         assert "Error" in result
         assert "not found" in result
 
+    def test_database_error(self):
+        with patch("mcp_server._get_skill_version_sync", return_value=(None, "database error")):
+            result = _run_complete_skill("my-skill", 4)
+        assert "Error" in result
+        assert "database unavailable" in result
+
     def test_valid_rating(self):
-        from mcp_server import complete_skill
-        with patch("mcp_server._get_skill_version_sync", return_value=3), \
-             patch("mcp_server._insert_rating_sync") as mock_insert, \
+        with patch("mcp_server._get_skill_version_sync", return_value=(3, None)), \
+             patch("mcp_server._insert_rating_sync", return_value=None) as mock_insert, \
              patch("mcp_server._resolve_session_meta", return_value={"client_name": "claude-code", "id": "sess-1"}):
-            result = asyncio.get_event_loop().run_until_complete(
-                complete_skill("my-skill", 4, "built the component")
-            )
+            result = _run_complete_skill("my-skill", 4, "built the component")
 
         assert "Completed" in result
         assert "4/5" in result
         mock_insert.assert_called_once_with("my-skill", 3, 4, "built the component", "claude-code", "sess-1")
 
     def test_valid_rating_no_outcome(self):
-        from mcp_server import complete_skill
-        with patch("mcp_server._get_skill_version_sync", return_value=1), \
-             patch("mcp_server._insert_rating_sync") as mock_insert, \
+        with patch("mcp_server._get_skill_version_sync", return_value=(1, None)), \
+             patch("mcp_server._insert_rating_sync", return_value=None) as mock_insert, \
              patch("mcp_server._resolve_session_meta", return_value=None):
-            result = asyncio.get_event_loop().run_until_complete(
-                complete_skill("my-skill", 5)
-            )
+            result = _run_complete_skill("my-skill", 5)
 
         assert "Completed" in result
         mock_insert.assert_called_once_with("my-skill", 1, 5, None, "", "")
+
+    def test_insert_failure(self):
+        with patch("mcp_server._get_skill_version_sync", return_value=(2, None)), \
+             patch("mcp_server._insert_rating_sync", return_value="failed to save rating"), \
+             patch("mcp_server._resolve_session_meta", return_value=None):
+            result = _run_complete_skill("my-skill", 3)
+
+        assert "Error" in result
+        assert "could not be saved" in result
+
+    def test_outcome_truncated(self):
+        long_outcome = "x" * 3000
+        with patch("mcp_server._get_skill_version_sync", return_value=(1, None)), \
+             patch("mcp_server._insert_rating_sync", return_value=None) as mock_insert, \
+             patch("mcp_server._resolve_session_meta", return_value=None):
+            _run_complete_skill("my-skill", 4, long_outcome)
+
+        # outcome should be capped at 2000 chars
+        call_args = mock_insert.call_args[0]
+        assert len(call_args[3]) == 2000
 
 
 class TestResolveSessionMeta:

--- a/backend/tests/unit/test_skill_ratings.py
+++ b/backend/tests/unit/test_skill_ratings.py
@@ -1,0 +1,79 @@
+"""Unit tests for the complete_skill MCP tool and rating helpers."""
+import asyncio
+
+import pytest
+from unittest.mock import patch
+
+
+class TestCompleteSkillValidation:
+    """Test rating validation logic."""
+
+    def test_rating_below_range(self):
+        from mcp_server import complete_skill
+        result = asyncio.get_event_loop().run_until_complete(complete_skill("test-skill", 0))
+        assert "Error" in result
+        assert "between 1 and 5" in result
+
+    def test_rating_above_range(self):
+        from mcp_server import complete_skill
+        result = asyncio.get_event_loop().run_until_complete(complete_skill("test-skill", 6))
+        assert "Error" in result
+        assert "between 1 and 5" in result
+
+    def test_nonexistent_skill(self):
+        from mcp_server import complete_skill
+        with patch("mcp_server._get_skill_version_sync", return_value=None):
+            result = asyncio.get_event_loop().run_until_complete(complete_skill("nonexistent", 4))
+        assert "Error" in result
+        assert "not found" in result
+
+    def test_valid_rating(self):
+        from mcp_server import complete_skill
+        with patch("mcp_server._get_skill_version_sync", return_value=3), \
+             patch("mcp_server._insert_rating_sync") as mock_insert, \
+             patch("mcp_server._resolve_session_meta", return_value={"client_name": "claude-code", "id": "sess-1"}):
+            result = asyncio.get_event_loop().run_until_complete(
+                complete_skill("my-skill", 4, "built the component")
+            )
+
+        assert "Completed" in result
+        assert "4/5" in result
+        mock_insert.assert_called_once_with("my-skill", 3, 4, "built the component", "claude-code", "sess-1")
+
+    def test_valid_rating_no_outcome(self):
+        from mcp_server import complete_skill
+        with patch("mcp_server._get_skill_version_sync", return_value=1), \
+             patch("mcp_server._insert_rating_sync") as mock_insert, \
+             patch("mcp_server._resolve_session_meta", return_value=None):
+            result = asyncio.get_event_loop().run_until_complete(
+                complete_skill("my-skill", 5)
+            )
+
+        assert "Completed" in result
+        mock_insert.assert_called_once_with("my-skill", 1, 5, None, "", "")
+
+
+class TestResolveSessionMeta:
+    def test_empty_connections(self):
+        from mcp_server import _resolve_session_meta, _active_connections
+        original = dict(_active_connections)
+        _active_connections.clear()
+        try:
+            result = _resolve_session_meta()
+            assert result is None
+        finally:
+            _active_connections.update(original)
+
+    def test_picks_most_recent(self):
+        from mcp_server import _resolve_session_meta, _active_connections
+        original = dict(_active_connections)
+        _active_connections.clear()
+        _active_connections["a"] = {"client_name": "old", "last_seen": 1.0, "id": "a"}
+        _active_connections["b"] = {"client_name": "new", "last_seen": 2.0, "id": "b"}
+        try:
+            result = _resolve_session_meta()
+            assert result is not None
+            assert result["client_name"] == "new"
+        finally:
+            _active_connections.clear()
+            _active_connections.update(original)

--- a/e2e/import-flow.spec.ts
+++ b/e2e/import-flow.spec.ts
@@ -254,8 +254,8 @@ test.describe('Import Modal — File Upload & Parsing', () => {
     await expect(page.getByText('skill-creator')).toBeVisible()
     // File count indicator
     await expect(page.getByText('1 file ready')).toBeVisible()
-    // Import button should show count
-    await expect(page.getByRole('button', { name: 'Import 1 skill' })).toBeVisible()
+    // Review & Create button should be visible for single file
+    await expect(page.getByRole('button', { name: 'Review & Create' })).toBeVisible()
   })
 
   test('file with title frontmatter uses title as name', async ({ page }) => {
@@ -272,12 +272,12 @@ test.describe('Import Modal — File Upload & Parsing', () => {
     await expect(page.getByText('Bare Skill')).toBeVisible()
   })
 
-  test('file with frontmatter tags shows them', async ({ page }) => {
+  test('file with frontmatter name shows in file list', async ({ page }) => {
     const filePath = writeTestFile('tagged.md', SKILL_WITH_TAGS_MD)
     await uploadFile(page, filePath)
 
-    // Tags from frontmatter should be visible in the subtitle
-    await expect(page.getByText('react, typescript')).toBeVisible()
+    // Skill name should be visible in the file list
+    await expect(page.getByText('tagged-skill')).toBeVisible()
   })
 
   test('remove button removes file from list', async ({ page }) => {
@@ -287,8 +287,8 @@ test.describe('Import Modal — File Upload & Parsing', () => {
     await expect(page.getByText('1 file ready')).toBeVisible()
     await page.getByLabel('Remove').click()
     await expect(page.getByText('1 file ready')).not.toBeVisible()
-    // Import button should be disabled
-    await expect(page.getByRole('button', { name: /Import/ }).last()).toBeDisabled()
+    // Review & Create button should no longer be visible
+    await expect(page.getByRole('button', { name: 'Review & Create' })).not.toBeVisible()
   })
 
   test('uploading multiple files shows count', async ({ page }) => {
@@ -298,13 +298,15 @@ test.describe('Import Modal — File Upload & Parsing', () => {
     await page.waitForTimeout(500)
 
     await expect(page.getByText('2 files ready')).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Import 2 skills' })).toBeVisible()
+    // Multiple files show individual review buttons
+    await expect(page.getByText('skill-creator').first()).toBeVisible()
+    await expect(page.getByText('Bare Skill').first()).toBeVisible()
   })
 })
 
-// ─── TAG & COLLECTION EDITING ────────────────────────────────────────
+// ─── COLLECTION EDITING ────────────────────────────────────────────
 
-test.describe('Import Modal — Tag & Collection Editing', () => {
+test.describe('Import Modal — Collection Editing', () => {
   test.beforeEach(async ({ page }) => {
     await clearStorage(page)
     await page.goto('/')
@@ -314,39 +316,8 @@ test.describe('Import Modal — Tag & Collection Editing', () => {
     await uploadFile(page, filePath)
   })
 
-  test('tag and collection inputs are auto-expanded for single file', async ({ page }) => {
-    await expect(page.locator('input[placeholder="Add tags..."]')).toBeVisible()
+  test('collection input is auto-expanded for single file', async ({ page }) => {
     await expect(page.locator('input[placeholder="Add to collection..."]')).toBeVisible()
-  })
-
-  test('can add a tag by typing and pressing Enter', async ({ page }) => {
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.click()
-    await tagInput.fill('ai')
-    await tagInput.press('Enter')
-    await page.waitForTimeout(300)
-
-    // Tag chip should appear
-    const tagChip = page.locator('span').filter({ hasText: 'ai' }).filter({ has: page.locator('button') })
-    await expect(tagChip.first()).toBeVisible()
-  })
-
-  test('can add multiple tags', async ({ page }) => {
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.click()
-    await tagInput.fill('ai')
-    await tagInput.press('Enter')
-    await page.waitForTimeout(200)
-
-    // After first tag, placeholder disappears — find input by parent
-    const tagSection = page.locator('label:has-text("Tags")').locator('..')
-    const innerInput = tagSection.locator('input')
-    await innerInput.fill('automation')
-    await innerInput.press('Enter')
-    await page.waitForTimeout(200)
-
-    // Subtitle should show both tags
-    await expect(page.getByText('ai, automation')).toBeVisible()
   })
 
   test('can add a collection', async ({ page }) => {
@@ -361,30 +332,29 @@ test.describe('Import Modal — Tag & Collection Editing', () => {
     await expect(colChip.first()).toBeVisible()
   })
 
-  test('can remove a tag by clicking X', async ({ page }) => {
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.fill('removeme')
-    await tagInput.press('Enter')
+  test('can remove a collection by clicking X', async ({ page }) => {
+    const colInput = page.locator('input[placeholder="Add to collection..."]')
+    await colInput.fill('removeme')
+    await colInput.press('Enter')
     await page.waitForTimeout(300)
 
-    // Find the tag chip (it contains the text and an X button inside it)
-    const tagSection = page.locator('label:has-text("Tags")').locator('..')
-    const chip = tagSection.locator('span').filter({ hasText: 'removeme' }).first()
+    // Find the collection chip
+    const colSection = page.locator('label:has-text("Collection")').locator('..')
+    const chip = colSection.locator('span').filter({ hasText: 'removeme' }).first()
     await expect(chip).toBeVisible()
     await chip.locator('button').click()
     await page.waitForTimeout(300)
 
-    // Tag chip should be gone from the tag section
-    await expect(tagSection.locator('span').filter({ hasText: 'removeme' })).not.toBeVisible()
+    // Chip should be gone
+    await expect(colSection.locator('span').filter({ hasText: 'removeme' })).not.toBeVisible()
   })
 
-  test('tag input shows suggestions from existing skills', async ({ page }) => {
-    // Seed a skill with tags, close modal, reload to pick up seeds, then re-open
+  test('collection input shows suggestions from existing skills', async ({ page }) => {
+    // Seed a skill with collections, close modal, reload to pick up seeds, then re-open
     await page.locator('.fixed.inset-0.z-50 button[aria-label="Close"]').click()
     await page.evaluate((skills) => {
       localStorage.setItem('skillnote:skills', JSON.stringify(skills))
     }, SEED_SKILLS)
-    // Update route mock to return seeded skills so sync doesn't overwrite
     await page.unroute('**/v1/**')
     await mockApi(page, SEED_SKILLS)
     await page.reload({ waitUntil: 'networkidle' })
@@ -393,234 +363,164 @@ test.describe('Import Modal — Tag & Collection Editing', () => {
     const filePath = writeTestFile('SKILL.md', SKILL_MD)
     await uploadFile(page, filePath)
 
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.click()
+    const colInput = page.locator('input[placeholder="Add to collection..."]')
+    await colInput.click()
     await page.waitForTimeout(500)
 
-    // Existing tags should appear as dropdown suggestions
+    // Existing collections should appear as dropdown suggestions
     const dropdown = page.locator('.absolute.left-0.right-0')
-    await expect(dropdown.getByText('testing')).toBeVisible()
-    await expect(dropdown.getByText('e2e')).toBeVisible()
+    await expect(dropdown.getByText('QA')).toBeVisible()
   })
 
-  test('collapsing and expanding file row toggles tag inputs', async ({ page }) => {
-    // Tags should be visible (auto-expanded)
-    await expect(page.locator('input[placeholder="Add tags..."]')).toBeVisible()
+  test('collapsing and expanding file row toggles collection input', async ({ page }) => {
+    // Collection input should be visible (auto-expanded)
+    await expect(page.locator('input[placeholder="Add to collection..."]')).toBeVisible()
 
     // Click file row to collapse
     await page.locator('.cursor-pointer').filter({ hasText: 'skill-creator' }).click()
     await page.waitForTimeout(200)
-    await expect(page.locator('input[placeholder="Add tags..."]')).not.toBeVisible()
+    await expect(page.locator('input[placeholder="Add to collection..."]')).not.toBeVisible()
 
     // Click again to expand
     await page.locator('.cursor-pointer').filter({ hasText: 'skill-creator' }).click()
     await page.waitForTimeout(200)
-    await expect(page.locator('input[placeholder="Add tags..."]')).toBeVisible()
+    await expect(page.locator('input[placeholder="Add to collection..."]')).toBeVisible()
   })
 })
 
-// ─── IMPORT EXECUTION ────────────────────────────────────────────────
+// ─── REVIEW & CREATE FLOW ───────────────────────────────────────────
 
-test.describe('Import Modal — Import Execution', () => {
+test.describe('Import Modal — Review & Create Flow', () => {
   test.beforeEach(async ({ page }) => {
     await clearStorage(page)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
   })
 
-  test('import saves skill to localStorage and shows on home page', async ({ page }) => {
+  test('Review & Create navigates to /skills/new with prefilled data', async ({ page }) => {
     await openImportModal(page)
     const filePath = writeTestFile('SKILL.md', SKILL_MD)
     await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
+    await page.getByRole('button', { name: 'Review & Create' }).click()
 
-    // Toast should appear
-    await expect(page.getByText('Imported 1 skill')).toBeVisible()
-    // Modal should close
-    await expect(page.getByText('Import Skills')).not.toBeVisible()
-    // Skill should appear on home page
-    await expect(page.getByText('skill-creator').first()).toBeVisible()
-    // Skill count should update
-    await expect(page.getByText('1').first()).toBeVisible()
+    // Should navigate to /skills/new with query params
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
+    expect(page.url()).toContain('/skills/new')
+    expect(page.url()).toContain('name=skill-creator')
   })
 
-  test('imported skill has correct data in localStorage', async ({ page }) => {
+  test('prefilled name appears in create form', async ({ page }) => {
+    await openImportModal(page)
+    const filePath = writeTestFile('SKILL.md', SKILL_MD)
+    await uploadFile(page, filePath)
+    await page.getByRole('button', { name: 'Review & Create' }).click()
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
+    await page.waitForLoadState('networkidle')
+
+    const nameInput = page.locator('input[placeholder="skill-name"]')
+    await expect(nameInput).toHaveValue('skill-creator')
+  })
+
+  test('prefilled description appears in create form', async ({ page }) => {
+    await openImportModal(page)
+    const filePath = writeTestFile('SKILL.md', SKILL_MD)
+    await uploadFile(page, filePath)
+    await page.getByRole('button', { name: 'Review & Create' }).click()
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
+    await page.waitForLoadState('networkidle')
+
+    const descInput = page.locator('textarea[placeholder*="Describe"]')
+    await expect(descInput).toContainText('Create new skills')
+  })
+
+  test('Review & Create with collection passes collection param', async ({ page }) => {
     await openImportModal(page)
     const filePath = writeTestFile('SKILL.md', SKILL_MD)
     await uploadFile(page, filePath)
 
-    // Add tags and collection
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.fill('ai')
-    await tagInput.press('Enter')
-    await page.waitForTimeout(200)
-
+    // Add a collection before review
     const colInput = page.locator('input[placeholder="Add to collection..."]')
     await colInput.fill('Tools')
     await colInput.press('Enter')
-    await page.waitForTimeout(200)
+    await page.waitForTimeout(300)
 
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
-
-    const skills = await getStoredSkills(page)
-    expect(skills).toHaveLength(1)
-
-    const skill = skills[0]
-    expect(skill.slug).toBe('skill-creator')
-    expect(skill.title).toBe('skill-creator')
-    expect(skill.description).toBe('Create new skills, modify and improve existing skills, and measure skill performance.')
-    expect(skill.tags).toContain('ai')
-    expect(skill.collections).toContain('tools')
-    expect(skill.current_version).toBe(1)
-    expect(skill.content_md).toContain('# Skill Creator')
-    expect(skill.created_at).toBeTruthy()
-    expect(skill.updated_at).toBeTruthy()
+    await page.getByRole('button', { name: 'Review & Create' }).click()
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
+    expect(page.url()).toContain('collections=tools')
   })
 
-  test('imported skill with version 1 shows v1 badge', async ({ page }) => {
+  test('modal closes after Review & Create', async ({ page }) => {
     await openImportModal(page)
     const filePath = writeTestFile('SKILL.md', SKILL_MD)
     await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
+    await page.getByRole('button', { name: 'Review & Create' }).click()
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
 
-    // v1 badge should be visible on the list item
-    await expect(page.getByText('v1')).toBeVisible()
-  })
-
-  test('import adds to existing skills (does not overwrite)', async ({ page }) => {
-    await seedStorage(page)
-    await page.reload({ waitUntil: 'networkidle' })
-
-    await openImportModal(page)
-    const filePath = writeTestFile('SKILL.md', SKILL_MD)
-    await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
-
-    const skills = await getStoredSkills(page)
-    expect(skills).toHaveLength(2)
-    expect(skills.map((s: any) => s.slug)).toContain('skill-creator')
-    expect(skills.map((s: any) => s.slug)).toContain('existing-skill')
-  })
-
-  test('importing multiple files creates all skills', async ({ page }) => {
-    await openImportModal(page)
-    const file1 = writeTestFile('skill1.md', SKILL_MD)
-    const file2 = writeTestFile('skill2.md', SKILL_MINIMAL_MD)
-    await page.locator('input[type=file]').setInputFiles([file1, file2])
-    await page.waitForTimeout(500)
-
-    await page.getByRole('button', { name: 'Import 2 skills' }).click()
-    await page.waitForTimeout(1000)
-
-    await expect(page.getByText('Imported 2 skills')).toBeVisible()
-    const skills = await getStoredSkills(page)
-    expect(skills).toHaveLength(2)
+    // Modal should be closed
+    await expect(page.getByText('Import Skills')).not.toBeVisible()
   })
 })
 
-// ─── SKILL DETAIL AFTER IMPORT ───────────────────────────────────────
+// ─── SKILL DETAIL FROM SEEDED DATA ──────────────────────────────────
 
-test.describe('Skill Detail — After Import', () => {
+test.describe('Skill Detail — From Seeded Data', () => {
   test.beforeEach(async ({ page }) => {
-    await clearStorage(page)
+    await seedStorage(page)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
-    await openImportModal(page)
-    const filePath = writeTestFile('SKILL.md', SKILL_MD)
-    await uploadFile(page, filePath)
-
-    // Add tags and collection before importing
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.fill('ai')
-    await tagInput.press('Enter')
-    await page.waitForTimeout(200)
-    const tagSection = page.locator('label:has-text("Tags")').locator('..')
-    await tagSection.locator('input').fill('skills')
-    await tagSection.locator('input').press('Enter')
-    await page.waitForTimeout(200)
-
-    const colInput = page.locator('input[placeholder="Add to collection..."]')
-    await colInput.fill('AI Tools')
-    await colInput.press('Enter')
-    await page.waitForTimeout(200)
-
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
   })
 
-  test('imported skill appears as clickable link on home page', async ({ page }) => {
-    const link = page.locator('a[href="/skills/skill-creator"]')
+  test('seeded skill appears as clickable link on home page', async ({ page }) => {
+    const link = page.locator('a[href="/skills/existing-skill"]')
     await expect(link).toBeVisible()
   })
 
-  test('clicking imported skill navigates to detail page', async ({ page }) => {
-    await page.locator('a[href="/skills/skill-creator"]').click()
-    await page.waitForURL('**/skills/skill-creator')
+  test('clicking skill navigates to detail page', async ({ page }) => {
+    await page.locator('a[href="/skills/existing-skill"]').click()
+    await page.waitForURL('**/skills/existing-skill')
     await page.waitForLoadState('networkidle')
 
-    expect(page.url()).toContain('/skills/skill-creator')
-    await expect(page.getByText('skill-creator').first()).toBeVisible()
+    expect(page.url()).toContain('/skills/existing-skill')
+    await expect(page.getByText('existing-skill').first()).toBeVisible()
   })
 
   test('detail page shows correct metadata', async ({ page }) => {
-    await page.goto('/skills/skill-creator')
+    await page.goto('/skills/existing-skill')
     await page.waitForLoadState('networkidle')
 
     // Name
-    await expect(page.getByText('skill-creator').first()).toBeVisible()
+    await expect(page.getByText('existing-skill').first()).toBeVisible()
     // Description
-    await expect(page.getByText('Create new skills, modify and improve existing skills')).toBeVisible()
+    await expect(page.getByText('An existing skill for testing')).toBeVisible()
     // Version badge
-    await expect(page.getByText('v1')).toBeVisible()
-    // Tags
-    await expect(page.getByText('ai').first()).toBeVisible()
-    await expect(page.getByText('skills').first()).toBeVisible()
-    // Collection
-    await expect(page.getByText('ai tools')).toBeVisible()
+    await expect(page.getByText('v2').first()).toBeVisible()
   })
 
   test('detail page renders markdown content', async ({ page }) => {
-    await page.goto('/skills/skill-creator')
+    await page.goto('/skills/existing-skill')
     await page.waitForLoadState('networkidle')
 
     // H1 from markdown body
-    await expect(page.getByRole('heading', { name: 'Skill Creator' })).toBeVisible()
-    // Feature list items
-    await expect(page.getByText('Draft skills from scratch')).toBeVisible()
-    await expect(page.getByText('Run evaluations')).toBeVisible()
-    await expect(page.getByText('Optimize descriptions')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Existing Skill' })).toBeVisible()
+    await expect(page.getByText('Some content')).toBeVisible()
   })
 
-  test('detail page has Edit, Versions, Export buttons', async ({ page }) => {
-    await page.goto('/skills/skill-creator')
+  test('detail page has Edit Skill, Versions, Export buttons', async ({ page }) => {
+    await page.goto('/skills/existing-skill')
     await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
 
-    await expect(page.getByRole('button', { name: 'Edit' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Edit Skill' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Versions' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Export' })).toBeVisible()
   })
 
-  test('versions page shows v1 for imported skill', async ({ page }) => {
-    // Read the imported skill from localStorage and update mock to include it
-    const importedSkills = await page.evaluate(() => {
-      const raw = localStorage.getItem('skillnote:skills')
-      return raw ? JSON.parse(raw) : []
-    })
-    await page.unroute('**/v1/**')
-    await mockApi(page, importedSkills)
-
-    await page.goto('/skills/skill-creator/versions')
+  test('versions page shows version info for seeded skill', async ({ page }) => {
+    await page.goto('/skills/existing-skill/versions')
     await page.waitForLoadState('networkidle')
 
-    await expect(page.getByText('Current: v1')).toBeVisible()
-    // Version entry should show v1 with Latest badge
+    await expect(page.getByText('Current: v2')).toBeVisible()
     await expect(page.getByText('Latest')).toBeVisible()
-    // Should NOT show "No versions yet"
-    await expect(page.getByText('No versions yet')).not.toBeVisible()
   })
 })
 
@@ -628,51 +528,19 @@ test.describe('Skill Detail — After Import', () => {
 
 test.describe('Home Page — Filter Sidebar', () => {
   test.beforeEach(async ({ page }) => {
-    await clearStorage(page)
+    await seedStorage(page)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
-
-    // Import a skill with tags and collection
-    await openImportModal(page)
-    const filePath = writeTestFile('SKILL.md', SKILL_MD)
-    await uploadFile(page, filePath)
-
-    const tagInput = page.locator('input[placeholder="Add tags..."]')
-    await tagInput.fill('ai')
-    await tagInput.press('Enter')
-    await page.waitForTimeout(200)
-    const tagSection = page.locator('label:has-text("Tags")').locator('..')
-    await tagSection.locator('input').fill('testing')
-    await tagSection.locator('input').press('Enter')
-    await page.waitForTimeout(200)
-
-    const colInput = page.locator('input[placeholder="Add to collection..."]')
-    await colInput.fill('Tools')
-    await colInput.press('Enter')
-    await page.waitForTimeout(200)
-
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
   })
 
-  test('filter sidebar shows imported tags', async ({ page }) => {
-    await expect(page.locator('aside').getByText('ai')).toBeVisible()
-    await expect(page.locator('aside').getByText('testing')).toBeVisible()
+  test('filter sidebar shows seeded collections', async ({ page }) => {
+    // The sidebar filter panel only shows collections (not tags)
+    await expect(page.locator('aside').getByText('QA')).toBeVisible()
   })
 
-  test('filter sidebar shows imported collection', async ({ page }) => {
-    await expect(page.locator('aside').getByText('tools')).toBeVisible()
-  })
-
-  test('clicking a tag filters skills', async ({ page }) => {
-    // Click the "ai" tag in sidebar
-    await page.locator('aside').getByText('ai').click()
-    await page.waitForTimeout(300)
-
-    // Filtered chip should appear
-    await expect(page.locator('main').getByText('filtered')).toBeVisible()
-    // Skill should still be visible (it has the "ai" tag)
-    await expect(page.getByText('skill-creator').first()).toBeVisible()
+  test('filter sidebar shows seeded collection', async ({ page }) => {
+    // The seed data has collection "QA"
+    await expect(page.locator('aside').getByText('QA')).toBeVisible()
   })
 
   test('tag count shows correct number', async ({ page }) => {
@@ -734,10 +602,8 @@ test.describe('Home Page — View Toggle', () => {
   })
 
   test('can toggle to grid view', async ({ page }) => {
-    // Click the grid view button (second button in the toggle group)
-    const viewToggle = page.locator('button[aria-label]').filter({ has: page.locator('svg') })
-    // Grid toggle is typically the second icon
-    await page.locator('button').filter({ has: page.locator('.lucide-layout-grid, .lucide-grid-2x2') }).click()
+    // Click the grid view button
+    await page.locator('button[aria-label="Grid view"]').click()
     await page.waitForTimeout(300)
 
     // Grid view shows cards in a grid layout
@@ -793,11 +659,16 @@ test.describe('Skill Detail — Delete Flow', () => {
   })
 
   test('more menu has delete option', async ({ page }) => {
-    // Open the more menu
-    await page.locator('button').filter({ has: page.locator('.lucide-more-horizontal, .lucide-ellipsis') }).click()
+    // Use JS click to avoid detach during React re-renders
+    await page.waitForTimeout(2000)
+    await page.evaluate(() => {
+      const btn = document.querySelector('button[aria-label="More options"]') as HTMLButtonElement
+      if (btn) btn.click()
+      else throw new Error('More options button not found')
+    })
     await page.waitForTimeout(300)
 
-    await expect(page.getByText('Delete')).toBeVisible()
+    await expect(page.getByText('Delete Skill')).toBeVisible()
   })
 })
 
@@ -833,49 +704,24 @@ test.describe('Import — Markdown Parsing Edge Cases', () => {
     await expect(page.getByText('Bare Skill')).toBeVisible()
   })
 
-  test('frontmatter description is used over content slice', async ({ page }) => {
+  test('frontmatter description is passed to create page', async ({ page }) => {
     const filePath = writeTestFile('SKILL.md', SKILL_MD)
     await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
+    await page.getByRole('button', { name: 'Review & Create' }).click()
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
 
-    const skills = await getStoredSkills(page)
-    expect(skills[0].description).toBe(
-      'Create new skills, modify and improve existing skills, and measure skill performance.'
-    )
+    // Description should be in the URL params
+    expect(page.url()).toContain('description=')
   })
 
-  test('frontmatter tags are parsed from bracket notation', async ({ page }) => {
-    const filePath = writeTestFile('tagged.md', SKILL_WITH_TAGS_MD)
-    await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
-
-    const skills = await getStoredSkills(page)
-    expect(skills[0].tags).toEqual(['react', 'typescript'])
-  })
-
-  test('imported skill gets current_version 1', async ({ page }) => {
+  test('frontmatter content is passed to create page', async ({ page }) => {
     const filePath = writeTestFile('SKILL.md', SKILL_MD)
     await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
+    await page.getByRole('button', { name: 'Review & Create' }).click()
+    await page.waitForURL('**/skills/new**', { timeout: 5000 })
 
-    const skills = await getStoredSkills(page)
-    expect(skills[0].current_version).toBe(1)
-  })
-
-  test('imported skill gets timestamps', async ({ page }) => {
-    const filePath = writeTestFile('SKILL.md', SKILL_MD)
-    await uploadFile(page, filePath)
-    await page.getByRole('button', { name: 'Import 1 skill' }).click()
-    await page.waitForTimeout(1000)
-
-    const skills = await getStoredSkills(page)
-    expect(skills[0].created_at).toBeTruthy()
-    expect(skills[0].updated_at).toBeTruthy()
-    // Should be valid ISO dates
-    expect(new Date(skills[0].created_at).getTime()).toBeGreaterThan(0)
+    // Content should be in the URL params
+    expect(page.url()).toContain('content=')
   })
 })
 
@@ -903,11 +749,7 @@ test.describe('Navigation — Sidebar Links', () => {
     expect(page.url()).toContain('/collections')
   })
 
-  test('sidebar Tags link navigates to tags page', async ({ page }) => {
-    await page.locator('a[href="/tags"]').and(page.locator(':visible')).first().click()
-    await page.waitForURL('**/tags')
-    expect(page.url()).toContain('/tags')
-  })
+  // Tags link removed — sidebar no longer has a Tags page link
 
   test('sidebar Settings link navigates to settings page', async ({ page }) => {
     await page.locator('a[href="/settings"]').and(page.locator(':visible')).first().click()

--- a/e2e/integrations.spec.ts
+++ b/e2e/integrations.spec.ts
@@ -232,7 +232,7 @@ test.describe('Scope selector dropdown', () => {
     await setupMocks(page)
     await goToIntegrations(page)
 
-    const trigger = page.locator('button').filter({ hasText: /All Skills/ })
+    const trigger = page.locator('button').filter({ hasText: /All Skills/ }).first()
     await trigger.click()
 
     const searchInput = page.locator('input[placeholder*="collections"]').first()
@@ -244,9 +244,8 @@ test.describe('Scope selector dropdown', () => {
     await page.keyboard.press('Enter')
 
     // Some collection should be selected now (trigger no longer says "All Skills")
-    const updatedTrigger = page.locator('button').first()
-    // The trigger text should NOT contain "All Skills" after Enter-selecting
-    await expect(page.locator('button').filter({ hasText: /All Skills/ })).not.toBeVisible({ timeout: 3000 })
+    // The trigger is the first button matching "click to filter by" which changes text
+    await expect(page.getByRole('button', { name: 'All Skills click to filter by' })).not.toBeVisible({ timeout: 3000 })
   })
 })
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * E2E: Settings page — MCP Tools toggles
+ *
+ * All API calls are mocked so tests run without a live backend.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+const DEFAULT_SETTINGS = {
+  complete_skill_enabled: 'true',
+  complete_skill_outcome_enabled: 'false',
+}
+
+async function setupMocks(page: Page, settings = DEFAULT_SETTINGS) {
+  // Settings GET
+  await page.route('**/v1/settings', (route, req) => {
+    if (req.method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(settings) })
+    }
+    if (req.method() === 'PUT') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) })
+    }
+    return route.continue()
+  })
+
+  // Skills list (needed for sidebar/home)
+  await page.route('**/v1/skills', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+
+  // Analytics ratings
+  await page.route('**/v1/analytics/ratings', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  )
+}
+
+test.describe('Settings Page — MCP Tools', () => {
+  test('shows MCP Tools section with toggles', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    await expect(page.locator('text=MCP Tools')).toBeVisible()
+    await expect(page.locator('text=Skill Completion Tracking')).toBeVisible()
+    await expect(page.locator('text=Outcome Field')).toBeVisible()
+  })
+
+  test('skill completion toggle is ON by default', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    const toggle = page.locator('button[role="switch"]').first()
+    await expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  test('outcome toggle is OFF by default and nested', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    const outcomeToggle = page.locator('button[role="switch"]').nth(1)
+    await expect(outcomeToggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  test('outcome toggle is disabled when completion tracking is off', async ({ page }) => {
+    await setupMocks(page, { complete_skill_enabled: 'false', complete_skill_outcome_enabled: 'false' })
+    await page.goto('/settings')
+
+    const outcomeToggle = page.locator('button[role="switch"]').nth(1)
+    await expect(outcomeToggle).toBeDisabled()
+  })
+
+  test('disabling completion tracking shows confirmation dialog', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    // Click the first toggle (Skill Completion Tracking) to disable
+    const toggle = page.locator('button[role="switch"]').first()
+    await toggle.click()
+
+    // Confirmation dialog should appear
+    await expect(page.getByRole('heading', { name: 'Disable Skill Completion' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Disable' })).toBeVisible()
+  })
+
+  test('cancelling confirmation dialog keeps toggle on', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    const toggle = page.locator('button[role="switch"]').first()
+    await toggle.click()
+
+    // Cancel
+    await page.getByRole('button', { name: 'Cancel' }).click()
+
+    // Toggle should still be on
+    await expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  test('confirming disable turns toggle off and calls API', async ({ page }) => {
+    let putCalled = false
+    await setupMocks(page)
+    await page.route('**/v1/settings', (route, req) => {
+      if (req.method() === 'PUT') {
+        putCalled = true
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) })
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(DEFAULT_SETTINGS) })
+    })
+
+    await page.goto('/settings')
+
+    const toggle = page.locator('button[role="switch"]').first()
+    await toggle.click()
+    await page.getByRole('button', { name: 'Disable' }).click()
+
+    // Toggle should now be off
+    await expect(toggle).toHaveAttribute('aria-checked', 'false')
+  })
+
+  test('pressing Escape closes confirmation dialog', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    const toggle = page.locator('button[role="switch"]').first()
+    await toggle.click()
+    await expect(page.getByRole('heading', { name: 'Disable Skill Completion' })).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('heading', { name: 'Disable Skill Completion' })).not.toBeVisible()
+    // Toggle should still be on
+    await expect(toggle).toHaveAttribute('aria-checked', 'true')
+  })
+
+  test('shows info box with benefits', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    await expect(page.locator('text=Identify high-performing skills')).toBeVisible()
+    await expect(page.locator('text=Track adoption trends')).toBeVisible()
+  })
+
+  test('shows About section', async ({ page }) => {
+    await setupMocks(page)
+    await page.goto('/settings')
+
+    await expect(page.locator('text=About')).toBeVisible()
+    await expect(page.locator('text=SkillNote v0.1.0')).toBeVisible()
+  })
+})

--- a/e2e/skill-ratings.spec.ts
+++ b/e2e/skill-ratings.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Skill Ratings', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the skills API
+    await page.route('**/v1/skills', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { name: 'React Component', slug: 'react-component', description: 'Build React components', collections: [], currentVersion: 3 },
+          { name: 'API Design', slug: 'api-design', description: 'Design REST APIs', collections: [], currentVersion: 1 },
+        ]),
+      }),
+    )
+
+    // Mock ratings list
+    await page.route('**/v1/analytics/ratings', (route) => {
+      if (route.request().url().includes('ratings/')) return route.fallback()
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          { slug: 'react-component', avg_rating: 4.3, rating_count: 18 },
+        ]),
+      })
+    })
+  })
+
+  test('shows star rating on skill cards in grid view', async ({ page }) => {
+    await page.goto('/')
+    // Switch to grid view
+    const gridButton = page.locator('button[aria-label="Grid view"]')
+    if (await gridButton.isVisible()) await gridButton.click()
+
+    // Check that star rating is visible for rated skill
+    const card = page.locator('a[href="/skills/react-component"]')
+    await expect(card.locator('text=4.3')).toBeVisible()
+  })
+
+  test('shows star rating on skill list items', async ({ page }) => {
+    await page.goto('/')
+    const listItem = page.locator('a[href="/skills/react-component"]')
+    await expect(listItem.locator('text=4.3')).toBeVisible()
+  })
+
+  test('shows rating detail on skill detail page', async ({ page }) => {
+    // Mock skill detail
+    await page.route('**/v1/skills/react-component', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: '1',
+          name: 'React Component',
+          slug: 'react-component',
+          description: 'Build React components',
+          content_md: '# React Component\n\nInstructions here.',
+          collections: [],
+          current_version: 3,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-03-01T00:00:00Z',
+        }),
+      }),
+    )
+
+    // Mock comments
+    await page.route('**/v1/skills/react-component/comments', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    )
+
+    // Mock rating detail
+    await page.route('**/v1/analytics/ratings/react-component', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          slug: 'react-component',
+          avg_rating: 4.3,
+          rating_count: 18,
+          versions: [
+            { version: 3, avg_rating: 2.1, rating_count: 5 },
+            { version: 2, avg_rating: 4.8, rating_count: 8 },
+            { version: 1, avg_rating: 4.0, rating_count: 5 },
+          ],
+        }),
+      }),
+    )
+
+    await page.goto('/skills/react-component')
+
+    // Overall rating in meta pills
+    await expect(page.locator('text=4.3')).toBeVisible()
+
+    // Per-version breakdown (on lg+ screens)
+    await expect(page.locator('text=Rating by Version')).toBeVisible()
+    await expect(page.locator('text=v3')).toBeVisible()
+    await expect(page.locator('text=2.1')).toBeVisible()
+  })
+})

--- a/e2e/skill-ratings.spec.ts
+++ b/e2e/skill-ratings.spec.ts
@@ -94,7 +94,7 @@ test.describe('Skill Ratings', () => {
 
     // Per-version breakdown (on lg+ screens)
     await expect(page.locator('text=Rating by Version')).toBeVisible()
-    await expect(page.locator('text=v3')).toBeVisible()
+    await expect(page.locator('text=v3').first()).toBeVisible()
     await expect(page.locator('text=2.1')).toBeVisible()
   })
 })

--- a/e2e/slug-auto-update.spec.ts
+++ b/e2e/slug-auto-update.spec.ts
@@ -138,6 +138,18 @@ async function seedAndNavigate(page: Page) {
   }, SEED_SKILLS)
 }
 
+/** Click a button that may be unstable due to React re-renders */
+async function clickUnstableButton(page: Page, name: string) {
+  // Wait for re-renders to settle, then force-click
+  await page.waitForTimeout(2000)
+  await page.evaluate((buttonName) => {
+    const buttons = Array.from(document.querySelectorAll('button'))
+    const btn = buttons.find(b => b.textContent?.trim() === buttonName)
+    if (btn) btn.click()
+    else throw new Error(`Button "${buttonName}" not found`)
+  }, name)
+}
+
 async function getStoredSkills(page: Page) {
   return page.evaluate(() => {
     const raw = localStorage.getItem('skillnote:skills')
@@ -155,9 +167,8 @@ test.describe('Slug auto-update — Rename via edit', () => {
   test('renaming a skill updates the URL to new slug', async ({ page }) => {
     await page.goto('/skills/api-reviewer')
     await page.waitForLoadState('networkidle')
-
-    // Enter edit mode
-    await page.getByRole('button', { name: 'Edit' }).click()
+    // Enter edit mode (use JS click to avoid detach during React re-renders)
+    await clickUnstableButton(page, 'Edit Skill')
     await expect(page.locator('.fixed.inset-0')).toBeVisible()
 
     // Clear and type new name
@@ -181,8 +192,9 @@ test.describe('Slug auto-update — Rename via edit', () => {
   test('localStorage updates slug after rename', async ({ page }) => {
     await page.goto('/skills/api-reviewer')
     await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
 
-    await page.getByRole('button', { name: 'Edit' }).click()
+    await page.getByRole('button', { name: 'Edit Skill' }).click()
     await expect(page.locator('.fixed.inset-0')).toBeVisible()
 
     const nameInput = page.locator('input[placeholder="skill-name"]')
@@ -206,8 +218,9 @@ test.describe('Slug auto-update — Rename via edit', () => {
   test('old slug returns not found after rename', async ({ page }) => {
     await page.goto('/skills/api-reviewer')
     await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
 
-    await page.getByRole('button', { name: 'Edit' }).click()
+    await page.getByRole('button', { name: 'Edit Skill' }).click()
     await expect(page.locator('.fixed.inset-0')).toBeVisible()
 
     const nameInput = page.locator('input[placeholder="skill-name"]')
@@ -285,7 +298,7 @@ test.describe('Slack-style name input — Edit mode', () => {
     await seedAndNavigate(page)
     await page.goto('/skills/api-reviewer')
     await page.waitForLoadState('networkidle')
-    await page.getByRole('button', { name: 'Edit' }).click()
+    await clickUnstableButton(page, 'Edit Skill')
     await expect(page.locator('.fixed.inset-0')).toBeVisible()
   })
 
@@ -382,18 +395,14 @@ test.describe('Import flow — Review before create', () => {
     const path = require('path')
     const dir = '/tmp/skillnote-e2e-slug'
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-    // Invalid name with uppercase — parseMarkdown will keep it as-is
-    const content = `---\ntitle: Invalid Name!\ndescription: Bad name.\n---\n\n# Invalid\n\nContent.`
+    // Reserved name — will fail validation after normalization
+    const content = `---\nname: anthropic\ndescription: Bad name.\n---\n\n# Anthropic\n\nContent.`
     fs.writeFileSync(path.join(dir, 'invalid.md'), content)
 
     await page.locator('input[type=file]').setInputFiles(path.join(dir, 'invalid.md'))
     await page.waitForTimeout(500)
 
-    // Expand the file entry to see error details
-    await page.locator('.cursor-pointer').filter({ hasText: 'Invalid Name!' }).click()
-    await page.waitForTimeout(300)
-
-    // Should show validation error
+    // File auto-expands for single file — should show validation error
     const errorText = page.locator('.text-destructive')
     await expect(errorText.first()).toBeVisible()
   })
@@ -419,7 +428,7 @@ test.describe('Import flow — Review before create', () => {
     await page.waitForTimeout(500)
 
     // Should show duplicate warning
-    await expect(page.getByText('already exists', { exact: false })).toBeVisible()
+    await expect(page.getByText('already exists', { exact: false }).first()).toBeVisible()
   })
 })
 
@@ -428,6 +437,7 @@ test.describe('Import flow — Review before create', () => {
 test.describe('Delete skill — backend integration', () => {
   test('delete calls backend API before removing from localStorage', async ({ page }) => {
     let deleteCalledWith: string | null = null
+    const deletedSlugs = new Set<string>()
 
     await page.route('**/v1/**', (route, request) => {
       const url = new URL(request.url())
@@ -435,17 +445,22 @@ test.describe('Delete skill — backend integration', () => {
 
       if (request.method() === 'DELETE' && /^\/v1\/skills\/[^/]+$/.test(path)) {
         deleteCalledWith = path.split('/').pop()!
+        deletedSlugs.add(deleteCalledWith)
         return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
       }
 
       if (request.method() === 'GET' && path === '/v1/skills') {
+        const remaining = SEED_SKILLS.filter(s => !deletedSlugs.has(s.slug))
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(
-          SEED_SKILLS.map(s => ({ name: s.title, slug: s.slug, description: s.description, tags: s.tags, collections: s.collections, currentVersion: s.current_version }))
+          remaining.map(s => ({ name: s.title, slug: s.slug, description: s.description, tags: s.tags, collections: s.collections, currentVersion: s.current_version }))
         )})
       }
 
       if (request.method() === 'GET' && /^\/v1\/skills\/[^/]+$/.test(path)) {
         const slug = path.split('/').pop()!
+        if (deletedSlugs.has(slug)) {
+          return route.fulfill({ status: 404, contentType: 'application/json', body: '{"error":{"code":"SKILL_NOT_FOUND"}}' })
+        }
         const skill = SEED_SKILLS.find(s => s.slug === slug)
         if (skill) {
           return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
@@ -473,11 +488,15 @@ test.describe('Delete skill — backend integration', () => {
     }, SEED_SKILLS)
     await page.goto('/skills/api-reviewer')
     await page.waitForLoadState('networkidle')
-
-    // Open more menu and click Delete
-    await page.locator('button').filter({ has: page.locator('.lucide-more-horizontal, .lucide-ellipsis') }).click()
+    // Open more menu (use JS click to avoid detach during React re-renders)
+    await page.waitForTimeout(2000)
+    await page.evaluate(() => {
+      const btn = document.querySelector('button[aria-label="More options"]') as HTMLButtonElement
+      if (btn) btn.click()
+      else throw new Error('More options button not found')
+    })
     await page.waitForTimeout(300)
-    await page.getByText('Delete').click()
+    await page.getByText('Delete Skill').click()
     await page.waitForTimeout(300)
 
     // Confirm delete
@@ -485,9 +504,9 @@ test.describe('Delete skill — backend integration', () => {
     await page.waitForTimeout(2000)
 
     // Verify API was called
-    const calledSlug = await page.evaluate(() => (window as any).__deleteCalledWith)
-    // The route handler captured the slug — we just need to verify it was called
-    // by checking that the skill is gone from localStorage
+    expect(deleteCalledWith).toBe('api-reviewer')
+    // Wait for sync to settle, then verify skill is gone from localStorage
+    await page.waitForTimeout(1000)
     const skills = await getStoredSkills(page)
     const slugs = skills.map((s: any) => s.slug)
     expect(slugs).not.toContain('api-reviewer')
@@ -538,11 +557,15 @@ test.describe('Delete skill — backend integration', () => {
     }, SEED_SKILLS)
     await page.goto('/skills/api-reviewer')
     await page.waitForLoadState('networkidle')
-
-    // Open more menu and click Delete
-    await page.locator('button').filter({ has: page.locator('.lucide-more-horizontal, .lucide-ellipsis') }).click()
+    // Open more menu (use JS click to avoid detach during React re-renders)
+    await page.waitForTimeout(2000)
+    await page.evaluate(() => {
+      const btn = document.querySelector('button[aria-label="More options"]') as HTMLButtonElement
+      if (btn) btn.click()
+      else throw new Error('More options button not found')
+    })
     await page.waitForTimeout(300)
-    await page.getByText('Delete').click()
+    await page.getByText('Delete Skill').click()
     await page.waitForTimeout(300)
 
     // Confirm delete

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillnote",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(app)/analytics/page.tsx
+++ b/src/app/(app)/analytics/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useState, useEffect, useCallback } from 'react'
+import React, { Suspense, useState, useEffect, useCallback } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { TopBar } from '@/components/layout/topbar'
 import { cn } from '@/lib/utils'
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import {
   Zap, BookOpen, Users, Activity, TrendingUp, Radio, WifiOff,
   ChevronDown, ChevronRight, RefreshCw, BarChart2, PieChart as PieChartIcon,
+  Star, Info, Award,
 } from 'lucide-react'
 import {
   ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid,
@@ -21,11 +22,17 @@ import {
   fetchAgents,
   fetchTimeline,
   fetchCollections,
+  fetchTopSkills,
+  fetchRatingSummary,
+  fetchSkillReviews,
   type AnalyticsSummary,
   type SkillCallStat,
   type AgentStat,
   type TimelinePoint,
   type CollectionStat,
+  type TopSkillStat,
+  type RatingSummary,
+  type SkillReview,
 } from '@/lib/api/analytics'
 
 // ─── MCP types ────────────────────────────────────────────────────────────────
@@ -405,6 +412,11 @@ function AnalyticsContent() {
   const [agents, setAgents] = useState<AgentStat[]>([])
   const [timeline, setTimeline] = useState<TimelinePoint[]>([])
   const [collections, setCollections] = useState<CollectionStat[]>([])
+  const [topSkills, setTopSkills] = useState<TopSkillStat[]>([])
+  const [ratingSummary, setRatingSummary] = useState<RatingSummary | null>(null)
+  const [expandedSkill, setExpandedSkill] = useState<string | null>(null)
+  const [skillReviews, setSkillReviews] = useState<SkillReview[]>([])
+  const [reviewsLoading, setReviewsLoading] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [trendPct, setTrendPct] = useState<number | null>(null)
@@ -427,18 +439,22 @@ function AnalyticsContent() {
   const fetchAll = useCallback(async () => {
     try {
       setError(null)
-      const [s, sc, ag, tl, col] = await Promise.all([
+      const [s, sc, ag, tl, col, ts, rs] = await Promise.all([
         fetchAnalyticsSummary(params),
         fetchSkillCalls(params),
         fetchAgents(params),
         fetchTimeline(params),
         fetchCollections(params),
+        fetchTopSkills({ days: params.days, limit: 10 }).catch(() => [] as TopSkillStat[]),
+        fetchRatingSummary({ days: params.days }).catch(() => null),
       ])
       setSummary(s)
       setSkillCalls(sc)
       setAgents(ag)
       setTimeline(tl)
       setCollections(col)
+      setTopSkills(ts)
+      setRatingSummary(rs)
       setLastUpdatedAt(new Date().toISOString())
       setFetchedAt(Date.now())
 
@@ -971,6 +987,307 @@ function AnalyticsContent() {
               </div>
             )}
           </section>
+
+          {/* ── Top Skills + Rating Summary ─────────────────────────────── */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+
+            {/* Top Skills — 2/3 width */}
+            <section className="lg:col-span-2 group rounded-xl border border-border/50 border-l-2 border-l-transparent hover:border-l-accent/50 bg-card overflow-hidden transition-colors">
+              <div className="px-4 py-3 border-b border-border/40 flex items-center gap-2 bg-gradient-to-r from-card to-muted/10">
+                <Award className="h-4 w-4 text-muted-foreground" />
+                <h2 className="text-[13px] font-semibold tracking-tight text-foreground">Top Skills</h2>
+                <div className="relative group/tip ml-1">
+                  <Info className="h-3 w-3 text-muted-foreground/40 cursor-help" />
+                  <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-64 px-3 py-2 rounded-lg bg-popover border border-border shadow-lg text-[11px] text-muted-foreground leading-relaxed opacity-0 pointer-events-none group-hover/tip:opacity-100 group-hover/tip:pointer-events-auto transition-opacity z-50">
+                    Ratings are provided by AI agents (Claude Code, Cursor, Codex, etc.) after they use a skill via MCP. The completion rate shows how often agents rate a skill after calling it.
+                  </div>
+                </div>
+                {!loading && topSkills.length > 0 && (
+                  <span className="ml-auto text-[11px] text-muted-foreground/50">
+                    {topSkills.length} skills
+                  </span>
+                )}
+              </div>
+
+              {loading ? (
+                <div className="p-4 space-y-2.5">
+                  {[...Array(5)].map((_, i) => <Skeleton key={i} className="h-10 w-full" />)}
+                </div>
+              ) : topSkills.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-10 text-center px-4">
+                  <Award className="h-7 w-7 text-muted-foreground/20" />
+                  <p className="text-[13px] text-muted-foreground/50">No skill data yet</p>
+                  <p className="text-[11px] text-muted-foreground/30">Skills appear here once agents start calling them via MCP</p>
+                </div>
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="w-full text-[12px]">
+                    <thead>
+                      <tr className="border-b border-border/30 text-muted-foreground/50 text-[10px] uppercase tracking-wider">
+                        <th className="text-left font-medium px-4 py-2">#</th>
+                        <th className="text-left font-medium px-2 py-2">Skill</th>
+                        <th className="text-right font-medium px-2 py-2">Calls</th>
+                        <th className="text-right font-medium px-2 py-2">
+                          <span className="inline-flex items-center gap-1">
+                            Rating
+                            <span className="relative group/rtip">
+                              <Info className="h-2.5 w-2.5 text-muted-foreground/30 cursor-help" />
+                              <span className="absolute right-0 bottom-full mb-1.5 w-48 px-2 py-1.5 rounded bg-popover border border-border shadow-lg text-[10px] text-muted-foreground leading-snug opacity-0 pointer-events-none group-hover/rtip:opacity-100 group-hover/rtip:pointer-events-auto transition-opacity z-50 normal-case tracking-normal font-normal">
+                                Average rating (1-5) given by MCP agents after using this skill
+                              </span>
+                            </span>
+                          </span>
+                        </th>
+                        <th className="text-right font-medium px-2 py-2">Reviews</th>
+                        <th className="text-right font-medium px-4 py-2">
+                          <span className="inline-flex items-center gap-1">
+                            Completion
+                            <span className="relative group/ctip">
+                              <Info className="h-2.5 w-2.5 text-muted-foreground/30 cursor-help" />
+                              <span className="absolute right-0 bottom-full mb-1.5 w-52 px-2 py-1.5 rounded bg-popover border border-border shadow-lg text-[10px] text-muted-foreground leading-snug opacity-0 pointer-events-none group-hover/ctip:opacity-100 group-hover/ctip:pointer-events-auto transition-opacity z-50 normal-case tracking-normal font-normal">
+                                % of tool calls where the agent rated the skill afterward via complete_skill
+                              </span>
+                            </span>
+                          </span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border/20">
+                      {topSkills.map((s, i) => {
+                        const isExpanded = expandedSkill === s.slug
+                        return (
+                          <React.Fragment key={s.slug}>
+                            <tr
+                              onClick={async () => {
+                                if (isExpanded) {
+                                  setExpandedSkill(null)
+                                  return
+                                }
+                                setExpandedSkill(s.slug)
+                                setReviewsLoading(true)
+                                try {
+                                  const reviews = await fetchSkillReviews(s.slug)
+                                  setSkillReviews(reviews)
+                                } catch {
+                                  setSkillReviews([])
+                                } finally {
+                                  setReviewsLoading(false)
+                                }
+                              }}
+                              className={cn(
+                                'hover:bg-accent/4 cursor-pointer transition-colors group/row',
+                                isExpanded && 'bg-accent/4'
+                              )}
+                            >
+                              <td className="px-4 py-2.5 text-muted-foreground/50 font-mono">{i + 1}</td>
+                              <td className="px-2 py-2.5">
+                                <span className="font-medium font-mono text-foreground group-hover/row:text-accent transition-colors">
+                                  {s.slug}
+                                </span>
+                              </td>
+                              <td className="px-2 py-2.5 text-right tabular-nums font-semibold text-foreground">
+                                {s.call_count.toLocaleString()}
+                              </td>
+                              <td className="px-2 py-2.5 text-right">
+                                {s.avg_rating != null && s.rating_count > 0 ? (
+                                  <span className="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                                    <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                                    {s.avg_rating.toFixed(1)}
+                                  </span>
+                                ) : (
+                                  <span className="text-muted-foreground/30">—</span>
+                                )}
+                              </td>
+                              <td className="px-2 py-2.5 text-right tabular-nums text-muted-foreground">
+                                {s.rating_count > 0 ? s.rating_count : '—'}
+                              </td>
+                              <td className="px-4 py-2.5 text-right">
+                                <div className="flex items-center justify-end gap-2">
+                                  {s.rating_count > 0 ? (
+                                    <span className={cn(
+                                      'tabular-nums font-medium',
+                                      s.completion_rate >= 60 ? 'text-emerald-500' :
+                                      s.completion_rate >= 30 ? 'text-amber-500' :
+                                      'text-muted-foreground/50'
+                                    )}>
+                                      {s.completion_rate.toFixed(0)}%
+                                    </span>
+                                  ) : (
+                                    <span className="text-muted-foreground/30">—</span>
+                                  )}
+                                  <ChevronDown className={cn(
+                                    'h-3 w-3 text-muted-foreground/30 transition-transform',
+                                    isExpanded && 'rotate-180'
+                                  )} />
+                                </div>
+                              </td>
+                            </tr>
+                            {isExpanded && (
+                              <tr>
+                                <td colSpan={6} className="px-4 py-0">
+                                  <div className="py-3 border-t border-border/20">
+                                    <div className="flex items-center justify-between mb-2">
+                                      <p className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground/40 font-medium flex items-center gap-1.5">
+                                        Agent Reviews
+                                        <span className="relative group/rvtip">
+                                          <Info className="h-2.5 w-2.5 text-muted-foreground/30 cursor-help" />
+                                          <span className="absolute left-0 bottom-full mb-1.5 w-52 px-2 py-1.5 rounded bg-popover border border-border shadow-lg text-[10px] text-muted-foreground leading-snug opacity-0 pointer-events-none group-hover/rvtip:opacity-100 group-hover/rvtip:pointer-events-auto transition-opacity z-50 normal-case tracking-normal font-normal">
+                                            These reviews are submitted by AI agents (via MCP) after they apply the skill and see the results
+                                          </span>
+                                        </span>
+                                      </p>
+                                      <button
+                                        onClick={(e) => { e.stopPropagation(); router.push(`/skills/${s.slug}`) }}
+                                        className="text-[10px] text-accent hover:text-accent/80 font-medium transition-colors"
+                                      >
+                                        View skill →
+                                      </button>
+                                    </div>
+                                    {reviewsLoading ? (
+                                      <div className="space-y-2">
+                                        {[...Array(3)].map((_, j) => <Skeleton key={j} className="h-12 w-full" />)}
+                                      </div>
+                                    ) : skillReviews.length === 0 ? (
+                                      <p className="text-[12px] text-muted-foreground/40 py-3 text-center">
+                                        No reviews yet — agents haven&apos;t provided outcome descriptions
+                                      </p>
+                                    ) : (
+                                      <div className="space-y-2 max-h-[300px] overflow-y-auto">
+                                        {skillReviews.map(review => {
+                                          const cat = categorize(review.agent_name)
+                                          const info = AGENT_CATALOG[cat] ?? AGENT_CATALOG.other
+                                          return (
+                                            <div key={review.id} className="flex gap-3 py-2 px-2 rounded-lg hover:bg-muted/20 transition-colors">
+                                              <div className="shrink-0 mt-0.5">
+                                                <span
+                                                  className="w-6 h-6 rounded-full flex items-center justify-center text-[9px] font-bold text-white"
+                                                  style={{ backgroundColor: info.color }}
+                                                >
+                                                  {info.label.charAt(0)}
+                                                </span>
+                                              </div>
+                                              <div className="flex-1 min-w-0">
+                                                <div className="flex items-center gap-2 mb-0.5">
+                                                  <span className="text-[11px] font-medium text-foreground">{info.label}</span>
+                                                  <span className="flex items-center gap-0.5 text-[10px] text-amber-600 dark:text-amber-400">
+                                                    {[...Array(5)].map((_, si) => (
+                                                      <Star
+                                                        key={si}
+                                                        className={cn(
+                                                          'h-2.5 w-2.5',
+                                                          si < review.rating
+                                                            ? 'fill-amber-400 text-amber-400'
+                                                            : 'text-muted-foreground/20'
+                                                        )}
+                                                      />
+                                                    ))}
+                                                  </span>
+                                                  <span className="text-[10px] font-mono text-muted-foreground/30">v{review.skill_version}</span>
+                                                  {review.created_at && (
+                                                    <span className="text-[10px] text-muted-foreground/30">{fmtRelative(review.created_at)}</span>
+                                                  )}
+                                                </div>
+                                                {review.outcome ? (
+                                                  <p className="text-[12px] text-muted-foreground/70 leading-relaxed">
+                                                    {review.outcome}
+                                                  </p>
+                                                ) : (
+                                                  <p className="text-[11px] text-muted-foreground/25 italic">No description provided</p>
+                                                )}
+                                              </div>
+                                            </div>
+                                          )
+                                        })}
+                                      </div>
+                                    )}
+                                  </div>
+                                </td>
+                              </tr>
+                            )}
+                          </React.Fragment>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </section>
+
+            {/* Rating Summary — 1/3 width */}
+            <section className="group rounded-xl border border-border/50 border-l-2 border-l-transparent hover:border-l-accent/50 bg-card overflow-hidden transition-colors">
+              <div className="px-4 py-3 border-b border-border/40 flex items-center gap-2 bg-gradient-to-r from-card to-muted/10">
+                <Star className="h-4 w-4 text-muted-foreground" />
+                <h2 className="text-[13px] font-semibold tracking-tight text-foreground">Rating Overview</h2>
+                <div className="relative group/tip ml-1">
+                  <Info className="h-3 w-3 text-muted-foreground/40 cursor-help" />
+                  <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 w-56 px-3 py-2 rounded-lg bg-popover border border-border shadow-lg text-[11px] text-muted-foreground leading-relaxed opacity-0 pointer-events-none group-hover/tip:opacity-100 group-hover/tip:pointer-events-auto transition-opacity z-50">
+                    Aggregated from ratings submitted by AI agents after they apply skills via the MCP complete_skill tool.
+                  </div>
+                </div>
+              </div>
+
+              {loading ? (
+                <div className="p-4 space-y-3">
+                  <Skeleton className="h-16 w-full" />
+                  <Skeleton className="h-24 w-full" />
+                </div>
+              ) : !ratingSummary || ratingSummary.total_ratings === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-10 text-center px-4">
+                  <Star className="h-7 w-7 text-muted-foreground/20" />
+                  <p className="text-[13px] text-muted-foreground/50">No ratings yet</p>
+                  <p className="text-[11px] text-muted-foreground/30 max-w-[200px]">
+                    Agents rate skills after using them via the MCP complete_skill tool
+                  </p>
+                </div>
+              ) : (
+                <div className="p-4 space-y-5">
+                  {/* Overall avg + total */}
+                  <div className="text-center">
+                    <div className="flex items-center justify-center gap-2 mb-1">
+                      <Star className="h-5 w-5 fill-amber-400 text-amber-400" />
+                      <span className="text-[28px] font-bold tabular-nums text-foreground">
+                        {ratingSummary.overall_avg?.toFixed(1) ?? '—'}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-muted-foreground/50">
+                      {ratingSummary.total_ratings.toLocaleString()} rating{ratingSummary.total_ratings !== 1 ? 's' : ''} across {ratingSummary.rated_skills} skill{ratingSummary.rated_skills !== 1 ? 's' : ''}
+                    </p>
+                    {ratingSummary.rating_agents > 0 && (
+                      <p className="text-[10px] text-muted-foreground/35 mt-0.5">
+                        from {ratingSummary.rating_agents} agent{ratingSummary.rating_agents !== 1 ? 's' : ''}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Distribution bars */}
+                  <div className="space-y-1.5">
+                    <p className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground/40 font-medium mb-2">Distribution</p>
+                    {[5, 4, 3, 2, 1].map(star => {
+                      const count = ratingSummary.distribution[star] ?? 0
+                      const pct = ratingSummary.total_ratings > 0
+                        ? (count / ratingSummary.total_ratings) * 100
+                        : 0
+                      return (
+                        <div key={star} className="flex items-center gap-2">
+                          <span className="text-[11px] font-mono text-muted-foreground w-4 text-right shrink-0">{star}</span>
+                          <Star className="h-2.5 w-2.5 text-amber-400 fill-amber-400 shrink-0" />
+                          <div className="flex-1 h-2 rounded-full bg-muted/40 overflow-hidden">
+                            <div
+                              className="h-full rounded-full bg-amber-400/70 transition-all duration-500"
+                              style={{ width: `${pct}%` }}
+                            />
+                          </div>
+                          <span className="text-[10px] tabular-nums text-muted-foreground/50 w-8 text-right shrink-0">
+                            {count}
+                          </span>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
 
           {/* ── Collections + Live Connections ──────────────────────────────── */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-5 pb-6">

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -4,8 +4,9 @@ import { TopBar } from '@/components/layout/topbar'
 import { SkillListItem } from '@/components/skills/skill-list-item'
 import { SkillCard } from '@/components/skills/skill-card'
 import { FilterPanel } from '@/components/filters/filter-panel'
-import { Skill } from '@/lib/mock-data'
+import { Skill, SkillRating } from '@/lib/mock-data'
 import { getSkills, syncSkillsFromApi } from '@/lib/skills-store'
+import { fetchSkillRatings } from '@/lib/api/skills'
 import { cn } from '@/lib/utils'
 import { SearchX, SlidersHorizontal, X, Sparkles } from 'lucide-react'
 
@@ -15,6 +16,7 @@ function SkillsPageInner() {
   const [searchQuery, setSearchQuery] = useState('')
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false)
   const [skills, setSkills] = useState<Skill[]>([])
+  const [ratingsMap, setRatingsMap] = useState<Map<string, SkillRating>>(new Map())
 
   // Load skills on mount + re-sync on focus, periodic, and when skills-store changes
   useEffect(() => {
@@ -22,6 +24,10 @@ function SkillsPageInner() {
     const refresh = () => setSkills(getSkills())
     setSkills(getSkills())
     sync()
+    // Fetch ratings (fail silently — online-only)
+    fetchSkillRatings()
+      .then(ratings => setRatingsMap(new Map(ratings.map(r => [r.slug, r]))))
+      .catch(() => {})
     const interval = setInterval(sync, 30_000)
     window.addEventListener('focus', sync)
     window.addEventListener('skillnote:skills-changed', refresh)
@@ -155,11 +161,11 @@ function SkillsPageInner() {
             </div>
           ) : view === 'list' ? (
             <div className="pb-24 lg:pb-0">
-              {filtered.map(skill => <SkillListItem key={skill.slug} skill={skill} />)}
+              {filtered.map(skill => <SkillListItem key={skill.slug} skill={skill} rating={ratingsMap.get(skill.slug)} />)}
             </div>
           ) : (
             <div className="p-4 sm:p-5 pb-24 lg:pb-5 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
-              {filtered.map(skill => <SkillCard key={skill.slug} skill={skill} />)}
+              {filtered.map(skill => <SkillCard key={skill.slug} skill={skill} rating={ratingsMap.get(skill.slug)} />)}
             </div>
           )}
         </main>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState, useCallback } from 'react'
-import { ExternalLink, Info, ChevronDown, ChevronUp } from 'lucide-react'
+import { ExternalLink, Info } from 'lucide-react'
 import { toast } from 'sonner'
 import { TopBar } from '@/components/layout/topbar'
 import { fetchSettings, updateSettings } from '@/lib/api/settings'
@@ -52,29 +52,10 @@ function ConfirmDialog({ open, onConfirm, onCancel, title, message }: {
 
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || '0.1.0'
 
-const CHANGELOG_ENTRIES = [
-  {
-    version: '0.1.0',
-    date: '2026-03-08',
-    changes: [
-      'Skill registry with offline-first localStorage + PostgreSQL sync',
-      'SKILL.md import/export with YAML frontmatter',
-      'Content versioning with history, compare, and restore',
-      'MCP server for AI agent integration',
-      'Skill rating and completion tracking via complete_skill',
-      'Analytics dashboard with usage trends',
-      'MCP Integrations page showing connected agents',
-      'Collections, command palette, keyboard shortcuts',
-      'Docker Compose deployment',
-    ],
-  },
-]
-
 export default function SettingsPage() {
   const [settings, setSettings] = useState<Record<string, string>>({})
   const [loaded, setLoaded] = useState(false)
   const [confirmDisable, setConfirmDisable] = useState(false)
-  const [changelogOpen, setChangelogOpen] = useState(false)
 
   useEffect(() => {
     fetchSettings()
@@ -182,35 +163,6 @@ export default function SettingsPage() {
                 </a>
               </div>
             </div>
-          </section>
-
-          {/* Changelog */}
-          <section className="mb-10">
-            <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-4">Changelog</h2>
-            <button
-              onClick={() => setChangelogOpen(!changelogOpen)}
-              className="w-full flex items-center justify-between px-3.5 py-2.5 rounded-lg border border-border hover:bg-muted/50 transition-colors"
-            >
-              <span className="text-[13px] font-medium text-foreground">v{CHANGELOG_ENTRIES[0].version} <span className="text-muted-foreground font-normal ml-1">({CHANGELOG_ENTRIES[0].date})</span></span>
-              {changelogOpen ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
-            </button>
-            {changelogOpen && (
-              <div className="mt-2 space-y-4">
-                {CHANGELOG_ENTRIES.map(entry => (
-                  <div key={entry.version} className="px-3.5 py-3 rounded-lg border border-border bg-muted/30">
-                    <p className="text-[13px] font-semibold text-foreground mb-2">v{entry.version} <span className="text-muted-foreground font-normal text-[12px]">{entry.date}</span></p>
-                    <ul className="space-y-1">
-                      {entry.changes.map((change, i) => (
-                        <li key={i} className="text-[12px] text-muted-foreground flex gap-2">
-                          <span className="text-accent shrink-0">+</span>
-                          {change}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
-              </div>
-            )}
           </section>
         </div>
       </div>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,9 +1,122 @@
 'use client'
 
-import { ExternalLink } from 'lucide-react'
+import { useEffect, useState, useCallback } from 'react'
+import { ExternalLink, Info, ChevronDown, ChevronUp } from 'lucide-react'
+import { toast } from 'sonner'
 import { TopBar } from '@/components/layout/topbar'
+import { fetchSettings, updateSettings } from '@/lib/api/settings'
+
+function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${checked ? 'bg-accent' : 'bg-muted-foreground/30'}`}
+    >
+      <span className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${checked ? 'translate-x-[18px]' : 'translate-x-[2px]'}`} />
+    </button>
+  )
+}
+
+function ConfirmDialog({ open, onConfirm, onCancel, title, message }: {
+  open: boolean; onConfirm: () => void; onCancel: () => void; title: string; message: string
+}) {
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, onCancel])
+
+  if (!open) return null
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onCancel}>
+      <div className="bg-background border border-border rounded-lg shadow-lg max-w-sm w-full mx-4 p-5" onClick={e => e.stopPropagation()}>
+        <h3 className="text-[15px] font-semibold text-foreground mb-2">{title}</h3>
+        <p className="text-[13px] text-muted-foreground mb-5">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button onClick={onCancel} className="px-3 py-1.5 text-[13px] rounded-md border border-border text-foreground hover:bg-muted transition-colors">
+            Cancel
+          </button>
+          <button onClick={onConfirm} className="px-3 py-1.5 text-[13px] rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors">
+            Disable
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || '0.1.0'
+
+const CHANGELOG_ENTRIES = [
+  {
+    version: '0.1.0',
+    date: '2026-03-08',
+    changes: [
+      'Skill registry with offline-first localStorage + PostgreSQL sync',
+      'SKILL.md import/export with YAML frontmatter',
+      'Content versioning with history, compare, and restore',
+      'MCP server for AI agent integration',
+      'Skill rating and completion tracking via complete_skill',
+      'Analytics dashboard with usage trends',
+      'MCP Integrations page showing connected agents',
+      'Collections, command palette, keyboard shortcuts',
+      'Docker Compose deployment',
+    ],
+  },
+]
 
 export default function SettingsPage() {
+  const [settings, setSettings] = useState<Record<string, string>>({})
+  const [loaded, setLoaded] = useState(false)
+  const [confirmDisable, setConfirmDisable] = useState(false)
+  const [changelogOpen, setChangelogOpen] = useState(false)
+
+  useEffect(() => {
+    fetchSettings()
+      .then(s => { setSettings(s); setLoaded(true) })
+      .catch(() => { setLoaded(true) })
+  }, [])
+
+  const update = useCallback(async (key: string, value: boolean) => {
+    const strVal = value ? 'true' : 'false'
+    const patch: Record<string, string> = { [key]: strVal }
+
+    // When disabling complete_skill, also disable outcome
+    if (key === 'complete_skill_enabled' && !value) {
+      patch['complete_skill_outcome_enabled'] = 'false'
+    }
+
+    setSettings(prev => ({ ...prev, ...patch }))
+    try {
+      await updateSettings(patch)
+      toast.success('Setting updated — MCP clients will refresh automatically')
+    } catch {
+      // Revert all changes
+      const revert: Record<string, string> = {}
+      for (const k of Object.keys(patch)) {
+        revert[k] = patch[k] === 'true' ? 'false' : 'true'
+      }
+      setSettings(prev => ({ ...prev, ...revert }))
+      toast.error('Failed to update setting')
+    }
+  }, [])
+
+  const handleCompleteSkillToggle = useCallback((value: boolean) => {
+    if (!value) {
+      setConfirmDisable(true)
+    } else {
+      update('complete_skill_enabled', true)
+    }
+  }, [update])
+
+  const csEnabled = settings['complete_skill_enabled'] === 'true'
+  const outcomeEnabled = settings['complete_skill_outcome_enabled'] === 'true'
+
   return (
     <>
       <TopBar showFab={false} />
@@ -11,11 +124,55 @@ export default function SettingsPage() {
         <div className="max-w-2xl mx-auto px-6 py-8">
           <h1 className="text-xl font-semibold text-foreground mb-8">Settings</h1>
 
+          {/* MCP Tools */}
+          {loaded && (
+            <section className="mb-10">
+              <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-4">MCP Tools</h2>
+
+              {/* Info box */}
+              <div className="flex gap-3 p-3.5 rounded-lg bg-muted/50 border border-border mb-6">
+                <Info className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
+                <div className="space-y-2 text-[13px] text-muted-foreground">
+                  <p>
+                    The <span className="font-mono text-[12px] text-foreground">complete_skill</span> tool creates a feedback loop between AI agents and your skill library. When enabled, agents can rate skills (1-5) after applying them, helping you:
+                  </p>
+                  <ul className="list-disc pl-4 space-y-1">
+                    <li>Identify high-performing skills and double down on what works</li>
+                    <li>Spot underperforming skills that need revision</li>
+                    <li>Track adoption trends across agents and versions on the Analytics page</li>
+                  </ul>
+                  <p>Changes take effect immediately for all connected MCP clients.</p>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-[14px] font-medium text-foreground">Skill Completion Tracking</p>
+                    <p className="text-[13px] text-muted-foreground mt-0.5">
+                      Include the <span className="font-mono text-[12px]">complete_skill</span> tool so agents can rate skills after use
+                    </p>
+                  </div>
+                  <Toggle checked={csEnabled} onChange={handleCompleteSkillToggle} />
+                </div>
+                <div className={`flex items-start justify-between gap-4 pl-4 border-l-2 border-border transition-opacity ${!csEnabled ? 'opacity-40' : ''}`}>
+                  <div>
+                    <p className="text-[14px] font-medium text-foreground">Outcome Field</p>
+                    <p className="text-[13px] text-muted-foreground mt-0.5">
+                      Ask agents to describe what they accomplished — adds an <span className="font-mono text-[12px]">outcome</span> parameter to the tool
+                    </p>
+                  </div>
+                  <Toggle checked={outcomeEnabled} onChange={v => update('complete_skill_outcome_enabled', v)} disabled={!csEnabled} />
+                </div>
+              </div>
+            </section>
+          )}
+
           {/* About */}
           <section className="mb-10">
             <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-4">About</h2>
             <div className="space-y-1.5">
-              <p className="text-[14px] font-semibold text-foreground">SkillNote <span className="text-[12px] font-normal text-muted-foreground ml-1">v0.1.0</span></p>
+              <p className="text-[14px] font-semibold text-foreground">SkillNote <span className="text-[12px] font-normal text-muted-foreground ml-1">v{APP_VERSION}</span></p>
               <div className="flex items-center gap-4 pt-2">
                 <a href="https://github.com/luna-prompts/skillnote" target="_blank" rel="noopener noreferrer" className="text-[13px] text-accent hover:underline inline-flex items-center gap-1">
                   View on GitHub <ExternalLink className="h-3 w-3" />
@@ -26,8 +183,45 @@ export default function SettingsPage() {
               </div>
             </div>
           </section>
+
+          {/* Changelog */}
+          <section className="mb-10">
+            <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-4">Changelog</h2>
+            <button
+              onClick={() => setChangelogOpen(!changelogOpen)}
+              className="w-full flex items-center justify-between px-3.5 py-2.5 rounded-lg border border-border hover:bg-muted/50 transition-colors"
+            >
+              <span className="text-[13px] font-medium text-foreground">v{CHANGELOG_ENTRIES[0].version} <span className="text-muted-foreground font-normal ml-1">({CHANGELOG_ENTRIES[0].date})</span></span>
+              {changelogOpen ? <ChevronUp className="h-4 w-4 text-muted-foreground" /> : <ChevronDown className="h-4 w-4 text-muted-foreground" />}
+            </button>
+            {changelogOpen && (
+              <div className="mt-2 space-y-4">
+                {CHANGELOG_ENTRIES.map(entry => (
+                  <div key={entry.version} className="px-3.5 py-3 rounded-lg border border-border bg-muted/30">
+                    <p className="text-[13px] font-semibold text-foreground mb-2">v{entry.version} <span className="text-muted-foreground font-normal text-[12px]">{entry.date}</span></p>
+                    <ul className="space-y-1">
+                      {entry.changes.map((change, i) => (
+                        <li key={i} className="text-[12px] text-muted-foreground flex gap-2">
+                          <span className="text-accent shrink-0">+</span>
+                          {change}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmDisable}
+        title="Disable Skill Completion Tracking?"
+        message="This will remove the complete_skill tool from all connected MCP clients immediately. Agents will no longer be able to rate skills after use. You can re-enable it at any time."
+        onConfirm={() => { setConfirmDisable(false); update('complete_skill_enabled', false) }}
+        onCancel={() => setConfirmDisable(false)}
+      />
     </>
   )
 }

--- a/src/app/(app)/skills/[slug]/page.tsx
+++ b/src/app/(app)/skills/[slug]/page.tsx
@@ -10,9 +10,17 @@ import { useRouter } from 'next/navigation'
 export default function SkillPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = use(params)
   const router = useRouter()
-  const [skill, setSkill] = useState<Skill | null>(() => getSkills().find(s => s.slug === slug) ?? null)
+  const [skill, setSkill] = useState<Skill | null>(null)
+  const [hydrated, setHydrated] = useState(false)
 
-  // Fetch full skill from API on mount + periodic sync every 30s
+  // Read localStorage only after hydration to avoid SSR mismatch
+  useEffect(() => {
+    const found = getSkills().find(s => s.slug === slug) ?? null
+    setSkill(found)
+    setHydrated(true)
+  }, [slug])
+
+  // Fetch full skill from API on mount
   useEffect(() => {
     fetchSkill(slug)
       .then(fullSkill => {
@@ -30,6 +38,10 @@ export default function SkillPage({ params }: { params: Promise<{ slug: string }
       router.replace(`/skills/${updated.slug}`)
     }
   }, [slug, router])
+
+  if (!hydrated) {
+    return null
+  }
 
   if (skill === null) {
     return (

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -133,6 +133,7 @@ export function Sidebar({ onClose }: { onClose?: () => void }) {
           <p className="text-[10px] text-[var(--muted-foreground)]/40">
             {connStatus === 'online' ? 'Connected' : connStatus === 'offline' ? 'Offline' : 'Admin'}
           </p>
+          <span className="ml-auto text-[9px] font-mono text-[var(--muted-foreground)]/30">v{process.env.NEXT_PUBLIC_APP_VERSION || '0.1.0'}</span>
         </div>
       </div>
     </aside>

--- a/src/components/skills/skill-card.tsx
+++ b/src/components/skills/skill-card.tsx
@@ -11,7 +11,7 @@ const CARD_ACCENTS = [
   { bg: 'bg-rose-500/10 dark:bg-rose-500/15', text: 'text-rose-600 dark:text-rose-400', border: 'border-rose-500/15', dot: 'bg-rose-400' },
 ]
 
-export function SkillCard({ skill, rating }: { skill: Skill; rating?: { avg_rating: number; rating_count: number } }) {
+export function SkillCard({ skill, rating }: { skill: Skill; rating?: { avg_rating: number | null; rating_count: number } }) {
   const initials = skill.title.split(' ').slice(0, 2).map(w => w[0]).join('').toUpperCase()
   const colorIdx = skill.title.charCodeAt(0) % CARD_ACCENTS.length
   const accent = CARD_ACCENTS[colorIdx]
@@ -68,10 +68,10 @@ export function SkillCard({ skill, rating }: { skill: Skill; rating?: { avg_rati
               </span>
             )}
           </div>
-          {rating && rating.rating_count > 0 && (
+          {rating && rating.rating_count > 0 && rating.avg_rating != null && (
             <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400">
               <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
-              {rating.avg_rating}
+              {rating.avg_rating.toFixed(1)}
               <span className="text-muted-foreground/40">({rating.rating_count})</span>
             </span>
           )}

--- a/src/components/skills/skill-card.tsx
+++ b/src/components/skills/skill-card.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Skill } from '@/lib/mock-data'
-import { MessageSquare, Paperclip } from 'lucide-react'
+import { MessageSquare, Paperclip, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const CARD_ACCENTS = [
@@ -11,7 +11,7 @@ const CARD_ACCENTS = [
   { bg: 'bg-rose-500/10 dark:bg-rose-500/15', text: 'text-rose-600 dark:text-rose-400', border: 'border-rose-500/15', dot: 'bg-rose-400' },
 ]
 
-export function SkillCard({ skill }: { skill: Skill }) {
+export function SkillCard({ skill, rating }: { skill: Skill; rating?: { avg_rating: number; rating_count: number } }) {
   const initials = skill.title.split(' ').slice(0, 2).map(w => w[0]).join('').toUpperCase()
   const colorIdx = skill.title.charCodeAt(0) % CARD_ACCENTS.length
   const accent = CARD_ACCENTS[colorIdx]
@@ -68,6 +68,13 @@ export function SkillCard({ skill }: { skill: Skill }) {
               </span>
             )}
           </div>
+          {rating && rating.rating_count > 0 && (
+            <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400">
+              <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+              {rating.avg_rating}
+              <span className="text-muted-foreground/40">({rating.rating_count})</span>
+            </span>
+          )}
         </div>
       </div>
     </Link>

--- a/src/components/skills/skill-detail.tsx
+++ b/src/components/skills/skill-detail.tsx
@@ -450,10 +450,10 @@ export function SkillDetail({ skill, onSkillUpdated }: { skill: Skill; onSkillUp
                       <Clock className="h-3 w-3" />
                       {formatRelative(skill.updated_at)}
                     </span>
-                    {ratingDetail && ratingDetail.rating_count > 0 && (
+                    {ratingDetail && ratingDetail.rating_count > 0 && ratingDetail.avg_rating != null && (
                       <span className="inline-flex items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2.5 py-1 rounded-full">
                         <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
-                        {ratingDetail.avg_rating}
+                        {ratingDetail.avg_rating.toFixed(1)}
                         <span className="text-muted-foreground/60">({ratingDetail.rating_count})</span>
                       </span>
                     )}
@@ -489,7 +489,7 @@ export function SkillDetail({ skill, onSkillUpdated }: { skill: Skill; onSkillUp
                 {/* Right: install strip + version ratings — visible on lg+ */}
                 <div className="hidden lg:block w-64 shrink-0 pt-1 space-y-6">
                   <InstallStrip slug={skill.slug} />
-                  {ratingDetail && ratingDetail.versions.length > 0 && (
+                  {ratingDetail && ratingDetail.versions?.length > 0 && (
                     <div>
                       <p className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground/40 font-medium mb-2">Rating by Version</p>
                       <div className="space-y-1.5">

--- a/src/components/skills/skill-detail.tsx
+++ b/src/components/skills/skill-detail.tsx
@@ -4,11 +4,11 @@ import { TopBar } from '@/components/layout/topbar'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Download, Pencil, GitBranch, Check, BookOpen, ArrowLeft, Link2, Star, Command, X, Keyboard, FileText, Search, FolderOpen, Share2, MoreHorizontal, Trash2, Clock, User, Terminal } from 'lucide-react'
-import { Skill, type Comment } from '@/lib/mock-data'
+import { Skill, type Comment, type SkillRatingDetail } from '@/lib/mock-data'
 import { getSkills, updateSkill, deleteSkillById, saveSkillEdit } from '@/lib/skills-store'
 import { validateSkillName, validateDescription } from '@/lib/skill-validation'
 import { generateMarkdown, triggerDownload } from '@/lib/markdown-utils'
-import { createCommentApi } from '@/lib/api/skills'
+import { createCommentApi, fetchSkillRatingDetail } from '@/lib/api/skills'
 import { toast } from 'sonner'
 import { formatRelative } from '@/lib/format'
 import { cn } from '@/lib/utils'
@@ -192,6 +192,13 @@ export function SkillDetail({ skill, onSkillUpdated }: { skill: Skill; onSkillUp
       localStorage.setItem(`starred-${skill.slug}`, String(!prev))
       return !prev
     })
+  }, [skill.slug])
+
+  const [ratingDetail, setRatingDetail] = useState<SkillRatingDetail | null>(null)
+
+  // Fetch rating detail on mount
+  useEffect(() => {
+    fetchSkillRatingDetail(skill.slug).then(setRatingDetail).catch(() => {})
   }, [skill.slug])
 
   const [showHelp, setShowHelp] = useState(false)
@@ -443,6 +450,13 @@ export function SkillDetail({ skill, onSkillUpdated }: { skill: Skill; onSkillUp
                       <Clock className="h-3 w-3" />
                       {formatRelative(skill.updated_at)}
                     </span>
+                    {ratingDetail && ratingDetail.rating_count > 0 && (
+                      <span className="inline-flex items-center gap-1.5 text-[11px] text-amber-600 dark:text-amber-400 bg-amber-500/10 px-2.5 py-1 rounded-full">
+                        <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                        {ratingDetail.avg_rating}
+                        <span className="text-muted-foreground/60">({ratingDetail.rating_count})</span>
+                      </span>
+                    )}
                     {skill.collections.map(c => (
                       <Link
                         key={c}
@@ -472,9 +486,26 @@ export function SkillDetail({ skill, onSkillUpdated }: { skill: Skill; onSkillUp
                   </div>
                 </div>
 
-                {/* Right: install strip — visible on lg+ */}
-                <div className="hidden lg:block w-64 shrink-0 pt-1">
+                {/* Right: install strip + version ratings — visible on lg+ */}
+                <div className="hidden lg:block w-64 shrink-0 pt-1 space-y-6">
                   <InstallStrip slug={skill.slug} />
+                  {ratingDetail && ratingDetail.versions.length > 0 && (
+                    <div>
+                      <p className="text-[10px] uppercase tracking-[0.15em] text-muted-foreground/40 font-medium mb-2">Rating by Version</p>
+                      <div className="space-y-1.5">
+                        {ratingDetail.versions.map(v => (
+                          <div key={v.version} className="flex items-center justify-between text-[11px]">
+                            <span className="font-mono text-muted-foreground">v{v.version}</span>
+                            <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                              <Star className="h-2.5 w-2.5 fill-amber-400 text-amber-400" />
+                              {v.avg_rating}
+                              <span className="text-muted-foreground/40">({v.rating_count})</span>
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/components/skills/skill-list-item.tsx
+++ b/src/components/skills/skill-list-item.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { FileText, MessageSquare, Paperclip, FolderOpen } from 'lucide-react'
+import { FileText, MessageSquare, Paperclip, FolderOpen, Star } from 'lucide-react'
 import { Skill } from '@/lib/mock-data'
 import { cn } from '@/lib/utils'
 
-export function SkillListItem({ skill }: { skill: Skill }) {
+export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_rating: number; rating_count: number } }) {
   const router = useRouter()
   const commentCount = skill.comments?.length ?? 0
   const attachCount = skill.attachments?.length ?? 0
@@ -72,6 +72,12 @@ export function SkillListItem({ skill }: { skill: Skill }) {
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
+          {rating && rating.rating_count > 0 && (
+            <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400 hidden sm:flex">
+              <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+              {rating.avg_rating}
+            </span>
+          )}
           {skill.current_version > 0 && (
             <span className="text-[10px] font-mono font-medium text-accent/70 bg-accent/10 px-1.5 py-0.5 rounded hidden sm:inline">
               v{skill.current_version}

--- a/src/components/skills/skill-list-item.tsx
+++ b/src/components/skills/skill-list-item.tsx
@@ -4,7 +4,7 @@ import { FileText, MessageSquare, Paperclip, FolderOpen, Star } from 'lucide-rea
 import { Skill } from '@/lib/mock-data'
 import { cn } from '@/lib/utils'
 
-export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_rating: number; rating_count: number } }) {
+export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_rating: number | null; rating_count: number } }) {
   const router = useRouter()
   const commentCount = skill.comments?.length ?? 0
   const attachCount = skill.attachments?.length ?? 0
@@ -55,7 +55,6 @@ export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_
                   return (
                     <span
                       key={c}
-                      role="link"
                       tabIndex={0}
                       onClick={e => { e.preventDefault(); e.stopPropagation(); router.push(`/collections/${colSlug}`) }}
                       onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); router.push(`/collections/${colSlug}`) } }}
@@ -72,10 +71,10 @@ export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
-          {rating && rating.rating_count > 0 && (
+          {rating && rating.rating_count > 0 && rating.avg_rating != null && (
             <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400 hidden sm:flex">
               <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
-              {rating.avg_rating}
+              {rating.avg_rating.toFixed(1)}
             </span>
           )}
           {skill.current_version > 0 && (

--- a/src/components/skills/tabs/SkillHistoryTab.tsx
+++ b/src/components/skills/tabs/SkillHistoryTab.tsx
@@ -1,24 +1,39 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { ChevronDown, ChevronRight, GitBranch, Check, RotateCcw } from 'lucide-react'
+import { ChevronDown, ChevronRight, GitBranch, Check, RotateCcw, Star, MessageSquare } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { type ContentVersion, type Skill } from '@/lib/mock-data'
-import { fetchContentVersions, setLatestVersionApi, restoreVersionApi } from '@/lib/api/skills'
+import { type ContentVersion, type Skill, type SkillRatingDetail } from '@/lib/mock-data'
+import { fetchContentVersions, setLatestVersionApi, restoreVersionApi, fetchSkillRatingDetail } from '@/lib/api/skills'
+import { fetchSkillReviews, type SkillReview } from '@/lib/api/analytics'
 import { getSkills } from '@/lib/skills-store'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
+
+function StarRating({ rating }: { rating: number }) {
+  return (
+    <span className="inline-flex gap-px">
+      {[1, 2, 3, 4, 5].map(i => (
+        <Star key={i} className={cn('h-3 w-3', i <= rating ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground/20')} />
+      ))}
+    </span>
+  )
+}
 
 function VersionEntry({
   v,
   isLast,
   onSetLatest,
   onRestore,
+  versionRating,
+  reviews,
 }: {
   v: ContentVersion
   isLast: boolean
   onSetLatest: (version: number) => void
   onRestore: (version: number) => void
+  versionRating?: { avg_rating: number; rating_count: number }
+  reviews: SkillReview[]
 }) {
   const [expanded, setExpanded] = useState(false)
   const [showRestore, setShowRestore] = useState(false)
@@ -55,6 +70,13 @@ function VersionEntry({
                   <Badge className="text-[10px] py-0 bg-accent/15 text-accent border-accent/30">
                     Latest
                   </Badge>
+                )}
+                {versionRating && versionRating.rating_count > 0 && (
+                  <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                    <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                    {versionRating.avg_rating.toFixed(1)}
+                    <span className="text-muted-foreground/50">({versionRating.rating_count})</span>
+                  </span>
                 )}
               </div>
               <p className="text-[12px] text-muted-foreground truncate">{v.title}</p>
@@ -100,7 +122,7 @@ function VersionEntry({
           </div>
           {expanded && (
             <div className="border-t border-border/60 bg-muted/20 p-4">
-              <div className="space-y-2 text-[12px]">
+              <div className="space-y-3 text-[12px]">
                 <div>
                   <span className="font-semibold text-muted-foreground">Description:</span>{' '}
                   <span className="text-foreground/80">{v.description || '(none)'}</span>
@@ -112,6 +134,34 @@ function VersionEntry({
                     {v.content_md.length > 200 && '...'}
                   </pre>
                 </div>
+                {reviews.length > 0 && (
+                  <div>
+                    <div className="flex items-center gap-1.5 mb-2">
+                      <MessageSquare className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span className="font-semibold text-muted-foreground">Reviews ({reviews.length})</span>
+                    </div>
+                    <div className="space-y-2">
+                      {reviews.map(r => (
+                        <div key={r.id} className="rounded-lg border border-border/40 bg-card/50 p-2.5">
+                          <div className="flex items-center gap-2 mb-1">
+                            <StarRating rating={r.rating} />
+                            {r.agent_name && (
+                              <span className="text-[10px] font-mono text-muted-foreground/60">{r.agent_name}</span>
+                            )}
+                            {r.created_at && (
+                              <span className="text-[10px] text-muted-foreground/40 ml-auto">
+                                {new Date(r.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                              </span>
+                            )}
+                          </div>
+                          {r.outcome && (
+                            <p className="text-[11px] text-foreground/70 mt-1">{r.outcome}</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -168,6 +218,8 @@ type SkillVersionsTabProps = {
 export function SkillVersionsTab({ skillSlug, onRestored }: SkillVersionsTabProps) {
   const [versions, setVersions] = useState<ContentVersion[]>([])
   const [loading, setLoading] = useState(true)
+  const [ratingDetail, setRatingDetail] = useState<SkillRatingDetail | null>(null)
+  const [reviews, setReviews] = useState<SkillReview[]>([])
 
   const loadVersions = () => {
     setLoading(true)
@@ -191,9 +243,29 @@ export function SkillVersionsTab({ skillSlug, onRestored }: SkillVersionsTabProp
       .finally(() => setLoading(false))
   }
 
+  const loadRatings = () => {
+    fetchSkillRatingDetail(skillSlug).then(setRatingDetail).catch(() => {})
+    fetchSkillReviews(skillSlug, 100).then(setReviews).catch(() => {})
+  }
+
   useEffect(() => {
     loadVersions()
+    loadRatings()
   }, [skillSlug])
+
+  // Build lookup maps for ratings and reviews by version
+  const ratingByVersion = new Map<number, { avg_rating: number; rating_count: number }>()
+  if (ratingDetail?.versions) {
+    for (const vr of ratingDetail.versions) {
+      ratingByVersion.set(vr.version, { avg_rating: vr.avg_rating, rating_count: vr.rating_count })
+    }
+  }
+  const reviewsByVersion = new Map<number, SkillReview[]>()
+  for (const r of reviews) {
+    const existing = reviewsByVersion.get(r.skill_version) || []
+    existing.push(r)
+    reviewsByVersion.set(r.skill_version, existing)
+  }
 
   const handleSetLatest = async (version: number) => {
     try {
@@ -236,6 +308,8 @@ export function SkillVersionsTab({ skillSlug, onRestored }: SkillVersionsTabProp
               isLast={i === versions.length - 1}
               onSetLatest={handleSetLatest}
               onRestore={handleRestore}
+              versionRating={ratingByVersion.get(v.version)}
+              reviews={reviewsByVersion.get(v.version) || []}
             />
           ))
         ) : (

--- a/src/lib/api/analytics.ts
+++ b/src/lib/api/analytics.ts
@@ -30,6 +30,32 @@ export type CollectionStat = {
   call_count: number
 }
 
+export type TopSkillStat = {
+  slug: string
+  call_count: number
+  last_called_at: string | null
+  avg_rating: number | null
+  rating_count: number
+  completion_rate: number
+}
+
+export type SkillReview = {
+  id: string
+  rating: number
+  outcome: string | null
+  agent_name: string
+  skill_version: number
+  created_at: string | null
+}
+
+export type RatingSummary = {
+  total_ratings: number
+  overall_avg: number | null
+  rated_skills: number
+  rating_agents: number
+  distribution: Record<number, number>
+}
+
 type AnalyticsParams = {
   days?: number
   agent?: string
@@ -63,4 +89,23 @@ export function fetchTimeline(params: AnalyticsParams = {}) {
 
 export function fetchCollections(params: AnalyticsParams = {}) {
   return apiRequest<CollectionStat[]>(`/v1/analytics/collections${buildQuery(params)}`)
+}
+
+export function fetchTopSkills(params: AnalyticsParams & { limit?: number } = {}) {
+  const q = new URLSearchParams()
+  if (params.days !== undefined) q.set('days', String(params.days))
+  if (params.limit !== undefined) q.set('limit', String(params.limit))
+  const s = q.toString()
+  return apiRequest<TopSkillStat[]>(`/v1/analytics/top-skills${s ? `?${s}` : ''}`)
+}
+
+export function fetchSkillReviews(slug: string, limit = 20) {
+  return apiRequest<SkillReview[]>(`/v1/analytics/ratings/${slug}/reviews?limit=${limit}`)
+}
+
+export function fetchRatingSummary(params: AnalyticsParams = {}) {
+  const q = new URLSearchParams()
+  if (params.days !== undefined) q.set('days', String(params.days))
+  const s = q.toString()
+  return apiRequest<RatingSummary>(`/v1/analytics/rating-summary${s ? `?${s}` : ''}`)
 }

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,0 +1,12 @@
+import { apiRequest } from './client'
+
+export function fetchSettings(): Promise<Record<string, string>> {
+  return apiRequest<Record<string, string>>('/v1/settings')
+}
+
+export function updateSettings(patch: Record<string, string>): Promise<{ status: string }> {
+  return apiRequest<{ status: string }>('/v1/settings', {
+    method: 'PUT',
+    body: JSON.stringify(patch),
+  })
+}

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -1,4 +1,4 @@
-import { Skill, Comment, ContentVersion } from '@/lib/mock-data'
+import { Skill, Comment, ContentVersion, SkillRating, SkillRatingDetail } from '@/lib/mock-data'
 import { apiRequest } from './client'
 
 type ApiSkillListItem = {
@@ -169,4 +169,13 @@ export async function restoreVersionApi(slug: string, version: number): Promise<
     method: 'POST',
   })
   return detailToSkill(detail)
+}
+
+// Ratings
+export async function fetchSkillRatings(): Promise<SkillRating[]> {
+  return apiRequest<SkillRating[]>('/v1/analytics/ratings')
+}
+
+export async function fetchSkillRatingDetail(slug: string): Promise<SkillRatingDetail> {
+  return apiRequest<SkillRatingDetail>(`/v1/analytics/ratings/${slug}`)
 }

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -81,7 +81,7 @@ export type Collection = {
 
 export type SkillRating = {
   slug: string
-  avg_rating: number
+  avg_rating: number | null
   rating_count: number
 }
 

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -79,6 +79,19 @@ export type Collection = {
   updated_at: string
 }
 
+export type SkillRating = {
+  slug: string
+  avg_rating: number
+  rating_count: number
+}
+
+export type SkillRatingDetail = {
+  slug: string
+  avg_rating: number | null
+  rating_count: number
+  versions: { version: number; avg_rating: number; rating_count: number }[]
+}
+
 export const mockTeamMembers: TeamMember[] = [
   { name: 'Alice', color: '#8b5cf6' },
   { name: 'Bob', color: '#ef4444' },

--- a/start.sh
+++ b/start.sh
@@ -39,6 +39,12 @@ echo ""
 # ── 1. Stop any existing stack ────────────────────────────────────
 step "Stopping any existing containers"
 docker compose -f "$PROJECT_DIR/docker-compose.yml" down 2>/dev/null || true
+sleep 1
+# Kill any leftover processes holding the ports
+lsof -ti :3000 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+lsof -ti :${API_PORT} 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+lsof -ti :${MCP_PORT} 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+sleep 1
 ok "Clean slate"
 
 # ── 2. Build and start full stack ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Agents rate skills after applying them via `complete_skill(skill_slug, rating, outcome)` MCP tool
- Agent identity (name, session) captured server-side from MCP connection — zero extra tokens from the LLM
- Skill tool responses include a "close the loop" nudge prompting agents to rate after use
- REST API endpoints for aggregate ratings (`GET /v1/analytics/ratings`) and per-version breakdown (`GET /v1/analytics/ratings/{slug}`)
- Frontend displays star ratings on skill cards, list items, and detail page with per-version regression detection

## Key files

| File | Change |
|------|--------|
| `backend/alembic/versions/0007_skill_ratings.py` | New migration |
| `backend/app/db/models/skill_rating.py` | New model |
| `backend/mcp_server.py` | `complete_skill` tool + helpers + nudge in skill response |
| `backend/app/api/analytics.py` | 2 new rating endpoints |
| `src/components/skills/skill-card.tsx` | Star rating display |
| `src/components/skills/skill-detail.tsx` | Rating + per-version breakdown |

## Test plan

- [x] Migration runs: `skill_ratings` table created with check constraint
- [x] MCP `complete_skill` tool: valid rating inserts row, invalid rating/slug returns error
- [x] Agent name captured from MCP session automatically
- [x] REST API returns correct aggregations
- [x] Backend unit tests pass (60/60)
- [ ] Frontend renders stars on skill cards and detail page
- [ ] E2E tests with mocked API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)