### PR TITLE
fix: require user confirmation before drafting a skill

### DIFF
--- a/plugin/agents/skill-creator.md
+++ b/plugin/agents/skill-creator.md
@@ -19,7 +19,17 @@ tools:
 
 You are a dedicated agent for creating high-quality, reusable skills and pushing them to the SkillNote registry.
 
-## Your Process
+## CRITICAL: Ask Before Drafting
+
+**Never draft a skill without explicit user confirmation first.** If you were invoked because the agent *noticed* a pattern (not because the user said "create a skill"), your first and only action must be to ask the user:
+
+> "I noticed [specific pattern]. Want me to save this as a reusable SkillNote skill?"
+
+Stop there. Wait for an explicit yes. Do NOT read files, draft fields, fetch collections, or present a draft until the user confirms. Unsolicited drafts waste the user's attention and feel pushy.
+
+If the user said "create a skill for X" or "save this pattern" explicitly, skip the confirmation and proceed to Step 1.
+
+## Your Process (only after confirmation)
 
 1. **Understand the pattern** — What convention or workflow needs to be captured? Read relevant code if needed to understand the full context.
 

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Review the conversation in $ARGUMENTS. Did the user establish a reusable coding pattern, workflow, or convention that could benefit other projects? Only respond {\"ok\": false, \"reason\": \"This looks like a reusable pattern. Run /skillnote:skill-push to save it as a skill.\"} if there is a CLEAR, specific, reusable pattern (not just a bug fix or one-off task). Otherwise respond {\"ok\": true}. Be very selective — most conversations do NOT contain reusable patterns.",
+            "prompt": "Review the conversation in $ARGUMENTS. Did the user establish a reusable coding pattern, workflow, or convention that could benefit other projects? Only respond {\"ok\": false, \"reason\": \"You noticed a potentially reusable pattern: [briefly name it]. ASK the user first: 'Want me to save this as a SkillNote skill?' Do NOT draft or create the skill until the user confirms. If they say yes, then run /skillnote:skill-push.\"} if there is a CLEAR, specific, reusable pattern (not just a bug fix or one-off task). Otherwise respond {\"ok\": true}. Be very selective — most conversations do NOT contain reusable patterns.",
             "timeout": 10
           }
         ]

--- a/plugin/skills/skill-push/SKILL.md
+++ b/plugin/skills/skill-push/SKILL.md
@@ -17,9 +17,15 @@ The SkillNote API is at: `http://${CLAUDE_PLUGIN_OPTION_HOST:-localhost}:8082`
 
 Only suggest for PERSISTENT conventions, not temporary workarounds.
 
-## Step 1: Confirm
+## Step 1: Confirm (REQUIRED — never skip)
 
-Tell the user what you noticed. Be specific. Ask: "Want me to create a skill for this?"
+**If the user did not explicitly ask to create a skill, you MUST ask first before doing anything else.**
+
+Tell the user what you noticed in one sentence. Be specific. Then ask: **"Want me to save this as a SkillNote skill?"**
+
+Stop and wait for an explicit yes. Do NOT draft the name/description/content, fetch collections, or present a preview until the user confirms. Unsolicited drafts feel pushy and waste attention.
+
+Skip this step only when the user already said "create a skill for X" / "save this pattern" / "push a skill" in their own words.
 
 ## Step 2: Draft
 


### PR DESCRIPTION
## Summary

- Stop hook, skill-creator agent, and skill-push skill now make "ask the user first" an explicit gate before drafting.
- Previously, when the Stop hook noticed a reusable pattern, Claude (or the skill-creator subagent) jumped straight into drafting name/description/content and presented an unsolicited skill. That felt pushy and wasted attention.
- New flow: notice pattern → ask "want me to save this as a skill?" → wait for yes → only then draft and push.

## Files Changed

- `plugin/hooks/hooks.json` — Stop hook prompt now instructs Claude to ask the user first instead of running `/skillnote:skill-push` immediately.
- `plugin/agents/skill-creator.md` — New "CRITICAL: Ask Before Drafting" section at the top; process steps are gated on confirmation.
- `plugin/skills/skill-push/SKILL.md` — Step 1 is now "Confirm (REQUIRED — never skip)" with explicit stop-and-wait instructions.

## Test plan

- [ ] Run a conversation where Claude completes a non-trivial reusable task.
- [ ] Verify the Stop hook fires and Claude asks "Want me to save this as a SkillNote skill?" instead of drafting unsolicited.
- [ ] Say "no" — verify Claude drops it.
- [ ] Say "yes" — verify Claude proceeds through draft → collection → push.
- [ ] Verify that explicitly saying "create a skill for X" still skips the confirmation and drafts immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)