### PR TITLE
[Superseded by #20] Release 0.3.1 — collections as first-class DB entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to SkillNote will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
-## 0.3.1 — 2026-04-15
+## [0.3.1] - 2026-04-15
 
 ### Fixed
 - Empty collections created in the web UI now appear in the CLI collection picker (`skillnote-pick`). Previously they were only written to browser localStorage and invisible to the backend.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to SkillNote will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## 0.3.1 — 2026-04-15
+
+### Fixed
+- Empty collections created in the web UI now appear in the CLI collection picker (`skillnote-pick`). Previously they were only written to browser localStorage and invisible to the backend.
+
+### Added
+- `collections` table with full CRUD: `POST/PUT/DELETE /v1/collections`. `DELETE` is refused with 409 when any skill still references the collection.
+- Auto-migration: existing `skillnote:collections-meta` localStorage entries are POSTed to the API on first load of `/collections`, then cleared from localStorage on success.
+
+### Changed
+- `GET /v1/collections` response now includes `description` field (additive, backwards-compatible).
+
 ## [0.3.0] - 2026-04-08
 
 ### Added

--- a/backend/alembic/versions/0011_collections_table.py
+++ b/backend/alembic/versions/0011_collections_table.py
@@ -1,0 +1,27 @@
+"""create collections table
+
+Revision ID: 0011_collections_table
+Revises: 0010_pick_sessions
+Create Date: 2026-04-15
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0011_collections_table'
+down_revision = '0010_pick_sessions'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'collections',
+        sa.Column('name', sa.Text(), primary_key=True),
+        sa.Column('description', sa.Text(), nullable=False, server_default=''),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('collections')

--- a/backend/app/api/collections.py
+++ b/backend/app/api/collections.py
@@ -66,8 +66,7 @@ def create_collection(payload: CollectionCreate, db: Session = Depends(get_db)):
     except IntegrityError:
         db.rollback()
         raise api_error(409, "COLLECTION_EXISTS", f'Collection "{payload.name}" already exists')
-    db.refresh(col)
-    return col
+    return db.query(Collection).filter(Collection.name == payload.name).first()
 
 
 @router.put("/{name}", response_model=CollectionDetail)
@@ -79,8 +78,7 @@ def update_collection(name: str, payload: CollectionUpdate, db: Session = Depend
     col.description = payload.description
     col.updated_at = datetime.now(timezone.utc)
     db.commit()
-    db.refresh(col)
-    return col
+    return db.query(Collection).filter(Collection.name == name).first()
 
 
 @router.delete("/{name}", status_code=http_status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/collections.py
+++ b/backend/app/api/collections.py
@@ -81,3 +81,28 @@ def update_collection(name: str, payload: CollectionUpdate, db: Session = Depend
     db.commit()
     db.refresh(col)
     return col
+
+
+@router.delete("/{name}", status_code=http_status.HTTP_204_NO_CONTENT)
+def delete_collection(name: str, db: Session = Depends(get_db)):
+    skill_ref_count = db.execute(
+        text(
+            "SELECT COUNT(*) FROM skills WHERE :name = ANY(collections)"
+        ),
+        {"name": name},
+    ).scalar()
+
+    if skill_ref_count and skill_ref_count > 0:
+        raise api_error(
+            409,
+            "COLLECTION_IN_USE",
+            f'Cannot delete "{name}": {skill_ref_count} skill(s) still reference it',
+        )
+
+    col = db.query(Collection).filter(Collection.name == name).first()
+    if not col:
+        raise api_error(404, "COLLECTION_NOT_FOUND", f'Collection "{name}" not found')
+
+    db.delete(col)
+    db.commit()
+    return None

--- a/backend/app/api/collections.py
+++ b/backend/app/api/collections.py
@@ -68,3 +68,16 @@ def create_collection(payload: CollectionCreate, db: Session = Depends(get_db)):
         raise api_error(409, "COLLECTION_EXISTS", f'Collection "{payload.name}" already exists')
     db.refresh(col)
     return col
+
+
+@router.put("/{name}", response_model=CollectionDetail)
+def update_collection(name: str, payload: CollectionUpdate, db: Session = Depends(get_db)):
+    col = db.query(Collection).filter(Collection.name == name).first()
+    if not col:
+        raise api_error(404, "COLLECTION_NOT_FOUND", f'Collection "{name}" not found')
+
+    col.description = payload.description
+    col.updated_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(col)
+    return col

--- a/backend/app/api/collections.py
+++ b/backend/app/api/collections.py
@@ -9,13 +9,33 @@ router = APIRouter(prefix="/v1/collections", tags=["collections"])
 
 @router.get("")
 def list_collections(db: Session = Depends(get_db)):
-    """Return distinct collection names with skill counts."""
+    """Return collection names + skill counts + description.
+
+    UNIONs collections-with-skills (derived from skills.collections arrays)
+    with explicitly-created empty collections from the collections table.
+    """
     rows = db.execute(
         text(
-            "SELECT name, COUNT(*) AS count FROM ("
-            "  SELECT unnest(collections) AS name FROM skills "
-            "  WHERE collections IS NOT NULL AND collections != '{}'"
-            ") sub GROUP BY name ORDER BY name"
+            """
+            SELECT name, count, COALESCE(c.description, '') AS description
+            FROM (
+                SELECT name, COUNT(*) AS count FROM (
+                    SELECT unnest(collections) AS name FROM skills
+                    WHERE collections IS NOT NULL AND collections != '{}'
+                ) sub GROUP BY name
+                UNION
+                SELECT name, 0 AS count FROM collections
+                WHERE name NOT IN (
+                    SELECT DISTINCT unnest(collections) FROM skills
+                    WHERE collections IS NOT NULL AND collections != '{}'
+                )
+            ) u
+            LEFT JOIN collections c USING (name)
+            ORDER BY name
+            """
         )
     ).mappings().all()
-    return [{"name": row["name"], "count": row["count"]} for row in rows]
+    return [
+        {"name": row["name"], "count": row["count"], "description": row["description"]}
+        for row in rows
+    ]

--- a/backend/app/api/collections.py
+++ b/backend/app/api/collections.py
@@ -1,8 +1,14 @@
-from fastapi import APIRouter, Depends
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, status as http_status
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.core.errors import api_error
+from app.db.models import Collection
 from app.db.session import get_db
+from app.schemas.collection import CollectionCreate, CollectionDetail, CollectionUpdate
 
 router = APIRouter(prefix="/v1/collections", tags=["collections"])
 
@@ -39,3 +45,26 @@ def list_collections(db: Session = Depends(get_db)):
         {"name": row["name"], "count": row["count"], "description": row["description"]}
         for row in rows
     ]
+
+
+@router.post("", response_model=CollectionDetail, status_code=http_status.HTTP_201_CREATED)
+def create_collection(payload: CollectionCreate, db: Session = Depends(get_db)):
+    existing = db.query(Collection).filter(Collection.name == payload.name).first()
+    if existing:
+        raise api_error(409, "COLLECTION_EXISTS", f'Collection "{payload.name}" already exists')
+
+    now = datetime.now(timezone.utc)
+    col = Collection(
+        name=payload.name,
+        description=payload.description,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(col)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise api_error(409, "COLLECTION_EXISTS", f'Collection "{payload.name}" already exists')
+    db.refresh(col)
+    return col

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -1,8 +1,9 @@
 from app.db.models.analytics_event import AnalyticsEvent
+from app.db.models.collection import Collection
 from app.db.models.comment import Comment
 from app.db.models.skill import Skill
 from app.db.models.skill_content_version import SkillContentVersion
 from app.db.models.skill_rating import SkillRating
 from app.db.models.skill_version import SkillVersion
 
-__all__ = ["Skill", "SkillVersion", "SkillContentVersion", "Comment", "AnalyticsEvent", "SkillRating"]
+__all__ = ["Skill", "SkillVersion", "SkillContentVersion", "Comment", "AnalyticsEvent", "SkillRating", "Collection"]

--- a/backend/app/db/models/collection.py
+++ b/backend/app/db/models/collection.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class Collection(Base):
+    __tablename__ = "collections"
+
+    name: Mapped[str] = mapped_column(Text, primary_key=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/schemas/collection.py
+++ b/backend/app/schemas/collection.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+from app.validators.collection_validator import validate_collection_name
+
+
+class CollectionListItem(BaseModel):
+    name: str
+    count: int
+    description: str = ""
+
+
+class CollectionCreate(BaseModel):
+    name: str
+    description: str = ""
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, v: str) -> str:
+        errors = validate_collection_name(v)
+        if errors:
+            raise ValueError("; ".join(errors))
+        return v.strip()
+
+    @field_validator("description")
+    @classmethod
+    def check_description(cls, v: Optional[str]) -> str:
+        if v is None:
+            return ""
+        if len(v) > 1024:
+            raise ValueError("Description must be 1024 characters or fewer")
+        return v.strip()
+
+
+class CollectionUpdate(BaseModel):
+    description: str
+
+    @field_validator("description")
+    @classmethod
+    def check_description(cls, v: str) -> str:
+        if v is None:
+            return ""
+        if len(v) > 1024:
+            raise ValueError("Description must be 1024 characters or fewer")
+        return v.strip()
+
+
+class CollectionDetail(BaseModel):
+    model_config = {"from_attributes": True}
+
+    name: str
+    description: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/validators/collection_validator.py
+++ b/backend/app/validators/collection_validator.py
@@ -1,0 +1,22 @@
+import re
+
+COLLECTION_NAME_MAX = 128
+XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
+
+
+def validate_collection_name(name: str) -> list[str]:
+    errors: list[str] = []
+    if name is None:
+        errors.append("Collection name is required")
+        return errors
+    stripped = name.strip()
+    if not stripped:
+        errors.append("Collection name is required")
+        return errors
+    if len(stripped) > COLLECTION_NAME_MAX:
+        errors.append(f"Collection name must be {COLLECTION_NAME_MAX} characters or fewer")
+    if "\n" in stripped or "\r" in stripped:
+        errors.append("Collection name cannot contain newlines")
+    if XML_TAG_RE.search(stripped):
+        errors.append("Collection name cannot contain XML tags")
+    return errors

--- a/backend/tests/integration/test_collections_api.py
+++ b/backend/tests/integration/test_collections_api.py
@@ -1,0 +1,62 @@
+"""Integration tests for /v1/collections CRUD.
+
+Requires a running backend on 127.0.0.1:8082 (`docker compose up api`).
+Tests skip if API unreachable.
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+BASE_URL = os.environ.get("SKILLNOTE_TEST_BASE_URL", "http://127.0.0.1:8082")
+
+
+def _request(method: str, path: str, body: dict | None = None):
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        method=method,
+        headers={"Content-Type": "application/json"} if body else {},
+        data=(json.dumps(body).encode() if body is not None else None),
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            text = r.read().decode()
+            return r.status, json.loads(text) if text else None
+    except urllib.error.HTTPError as e:
+        text = e.read().decode()
+        return e.code, json.loads(text) if text else None
+    except Exception as e:
+        pytest.skip(f"API not reachable: {e}")
+
+
+@pytest.fixture
+def unique_name():
+    return f"test-col-{uuid.uuid4().hex[:8]}"
+
+
+def test_create_empty_collection_appears_in_list(unique_name):
+    status, _ = _request("POST", "/v1/collections", {"name": unique_name, "description": "desc"})
+    assert status == 201
+
+    status, cols = _request("GET", "/v1/collections")
+    assert status == 200
+    names = [c["name"] for c in cols]
+    assert unique_name in names
+
+    match = next(c for c in cols if c["name"] == unique_name)
+    assert match["count"] == 0
+    assert match["description"] == "desc"
+
+    _request("DELETE", f"/v1/collections/{unique_name}")
+
+
+def test_list_shape_includes_description_field():
+    status, cols = _request("GET", "/v1/collections")
+    assert status == 200
+    if cols:
+        assert "description" in cols[0]
+        assert "name" in cols[0]
+        assert "count" in cols[0]

--- a/backend/tests/integration/test_collections_api.py
+++ b/backend/tests/integration/test_collections_api.py
@@ -111,3 +111,37 @@ def test_put_returns_404_when_not_exists():
     status, body = _request("PUT", "/v1/collections/does-not-exist-xyz", {"description": "x"})
     assert status == 404
     assert body["error"]["code"] == "COLLECTION_NOT_FOUND"
+
+
+def test_delete_empty_collection(unique_name):
+    _request("POST", "/v1/collections", {"name": unique_name, "description": ""})
+
+    status, _ = _request("DELETE", f"/v1/collections/{unique_name}")
+    assert status == 204
+
+    status, cols = _request("GET", "/v1/collections")
+    names = [c["name"] for c in cols]
+    assert unique_name not in names
+
+
+def test_delete_404_when_not_exists():
+    status, body = _request("DELETE", "/v1/collections/does-not-exist-xyz")
+    assert status == 404
+
+
+def test_delete_409_when_skills_reference(unique_name):
+    """Creating a skill in a collection implicitly registers it — DELETE should refuse."""
+    skill_slug = f"test-skill-{uuid.uuid4().hex[:8]}"
+    _request("POST", "/v1/skills", {
+        "name": skill_slug,
+        "slug": skill_slug,
+        "description": "test fixture",
+        "content_md": "",
+        "collections": [unique_name],
+    })
+
+    status, body = _request("DELETE", f"/v1/collections/{unique_name}")
+    assert status == 409
+    assert body["error"]["code"] == "COLLECTION_IN_USE"
+
+    _request("DELETE", f"/v1/skills/{skill_slug}")

--- a/backend/tests/integration/test_collections_api.py
+++ b/backend/tests/integration/test_collections_api.py
@@ -60,3 +60,34 @@ def test_list_shape_includes_description_field():
         assert "description" in cols[0]
         assert "name" in cols[0]
         assert "count" in cols[0]
+
+
+def test_post_creates_collection(unique_name):
+    status, body = _request("POST", "/v1/collections", {"name": unique_name, "description": ""})
+    assert status == 201
+    assert body["name"] == unique_name
+
+    _request("DELETE", f"/v1/collections/{unique_name}")
+
+
+def test_post_duplicate_returns_409(unique_name):
+    _request("POST", "/v1/collections", {"name": unique_name, "description": ""})
+    status, body = _request("POST", "/v1/collections", {"name": unique_name, "description": ""})
+    assert status == 409
+    assert body["error"]["code"] == "COLLECTION_EXISTS"
+
+    _request("DELETE", f"/v1/collections/{unique_name}")
+
+
+def test_post_rejects_empty_name():
+    status, _ = _request("POST", "/v1/collections", {"name": "", "description": ""})
+    assert status == 422
+
+
+def test_post_trims_whitespace(unique_name):
+    padded = f"  {unique_name}  "
+    status, body = _request("POST", "/v1/collections", {"name": padded, "description": ""})
+    assert status == 201
+    assert body["name"] == unique_name
+
+    _request("DELETE", f"/v1/collections/{unique_name}")

--- a/backend/tests/integration/test_collections_api.py
+++ b/backend/tests/integration/test_collections_api.py
@@ -91,3 +91,23 @@ def test_post_trims_whitespace(unique_name):
     assert body["name"] == unique_name
 
     _request("DELETE", f"/v1/collections/{unique_name}")
+
+
+def test_put_updates_description(unique_name):
+    _request("POST", "/v1/collections", {"name": unique_name, "description": "original"})
+
+    status, body = _request("PUT", f"/v1/collections/{unique_name}", {"description": "updated"})
+    assert status == 200
+    assert body["description"] == "updated"
+
+    status, cols = _request("GET", "/v1/collections")
+    match = next(c for c in cols if c["name"] == unique_name)
+    assert match["description"] == "updated"
+
+    _request("DELETE", f"/v1/collections/{unique_name}")
+
+
+def test_put_returns_404_when_not_exists():
+    status, body = _request("PUT", "/v1/collections/does-not-exist-xyz", {"description": "x"})
+    assert status == 404
+    assert body["error"]["code"] == "COLLECTION_NOT_FOUND"

--- a/backend/tests/unit/test_collection_validator.py
+++ b/backend/tests/unit/test_collection_validator.py
@@ -1,0 +1,33 @@
+"""Unit tests for collection name validation."""
+from app.validators.collection_validator import validate_collection_name
+
+
+class TestValidateCollectionName:
+    def test_valid_name_with_spaces(self):
+        assert validate_collection_name("lp assessment") == []
+
+    def test_valid_single_word(self):
+        assert validate_collection_name("frontend") == []
+
+    def test_empty_rejected(self):
+        errors = validate_collection_name("")
+        assert any("required" in e.lower() for e in errors)
+
+    def test_whitespace_only_rejected(self):
+        errors = validate_collection_name("   ")
+        assert any("required" in e.lower() for e in errors)
+
+    def test_too_long_rejected(self):
+        errors = validate_collection_name("x" * 129)
+        assert any("128" in e for e in errors)
+
+    def test_newline_rejected(self):
+        errors = validate_collection_name("foo\nbar")
+        assert any("newline" in e.lower() or "invalid" in e.lower() for e in errors)
+
+    def test_xml_tag_rejected(self):
+        errors = validate_collection_name("<script>")
+        assert any("xml" in e.lower() or "tag" in e.lower() for e in errors)
+
+    def test_boundary_128_chars_accepted(self):
+        assert validate_collection_name("x" * 128) == []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillnote",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(app)/collections/page.tsx
+++ b/src/app/(app)/collections/page.tsx
@@ -5,7 +5,8 @@ import { FolderOpen, Plus, ArrowRight, Info } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useEffect, useMemo, useState } from 'react'
 import { getSkills, syncSkillsFromApi } from '@/lib/skills-store'
-import { deriveCollections } from '@/lib/derived'
+import { deriveCollectionsFromApi } from '@/lib/derived'
+import { createCollectionApi, fetchCollectionsApi, type CollectionListItem } from '@/lib/api/collections'
 import { NewCollectionModal } from '@/components/collections/NewCollectionModal'
 import type { Skill } from '@/lib/mock-data'
 
@@ -17,16 +18,64 @@ function getSkillsForCollection(skills: Skill[], name: string): Skill[] {
 
 export default function CollectionsPage() {
   const [skills, setSkills] = useState(getSkills())
+  const [apiCollections, setApiCollections] = useState<CollectionListItem[]>([])
   const [newCollectionOpen, setNewCollectionOpen] = useState(false)
+
+  // One-shot migration: push stale localStorage-meta entries to the API.
+  async function migrateLocalStorageCollections(apiNames: Set<string>) {
+    let meta: Record<string, { description: string; created_at: string }>
+    try {
+      meta = JSON.parse(localStorage.getItem('skillnote:collections-meta') || '{}')
+    } catch {
+      return
+    }
+    const toMigrate = Object.entries(meta).filter(([name]) => !apiNames.has(name))
+    if (toMigrate.length === 0) return
+
+    const succeeded: string[] = []
+    for (const [name, data] of toMigrate) {
+      try {
+        await createCollectionApi(name, data.description || '')
+        succeeded.push(name)
+      } catch {
+        // Leave in localStorage; try again next page load
+      }
+    }
+    if (succeeded.length === 0) return
+
+    // Remove migrated entries from localStorage
+    const remaining = { ...meta }
+    for (const name of succeeded) delete remaining[name]
+    localStorage.setItem('skillnote:collections-meta', JSON.stringify(remaining))
+
+    // Re-fetch so UI reflects migrated collections
+    try {
+      const fresh = await fetchCollectionsApi()
+      setApiCollections(fresh)
+    } catch {}
+  }
 
   useEffect(() => {
     syncSkillsFromApi().then(setSkills).catch(() => {})
+    fetchCollectionsApi()
+      .then(async (cols) => {
+        setApiCollections(cols)
+        await migrateLocalStorageCollections(new Set(cols.map(c => c.name)))
+      })
+      .catch(() => {})
   }, [])
 
-  const collections = useMemo(() => deriveCollections(skills), [skills])
+  const collections = useMemo(
+    () => deriveCollectionsFromApi(skills, apiCollections),
+    [skills, apiCollections],
+  )
 
-  function handleCollectionCreated() {
+  async function handleCollectionCreated() {
     setSkills(s => [...s])
+    try {
+      const fresh = await fetchCollectionsApi()
+      setApiCollections(fresh)
+    } catch {}
     setNewCollectionOpen(false)
   }
 

--- a/src/components/collections/CollectionPicker.tsx
+++ b/src/components/collections/CollectionPicker.tsx
@@ -2,6 +2,7 @@
 import { useState, useMemo, useRef, useEffect } from 'react'
 import { Plus, X, FolderOpen, Check, Search } from 'lucide-react'
 import { getSkills } from '@/lib/skills-store'
+import { createCollectionApi, fetchCollectionsApi } from '@/lib/api/collections'
 
 type Props = {
   selected: string[]
@@ -11,15 +12,23 @@ type Props = {
   compact?: boolean
 }
 
-function getAllCollections(): string[] {
+async function getAllCollectionsAsync(): Promise<string[]> {
   const set = new Set<string>()
   try {
     for (const s of getSkills()) {
       for (const c of s.collections || []) set.add(c)
     }
-    const meta = JSON.parse(localStorage.getItem('skillnote:collections-meta') || '{}')
-    for (const name of Object.keys(meta)) set.add(name)
   } catch {}
+  try {
+    const apiCols = await fetchCollectionsApi()
+    for (const c of apiCols) set.add(c.name)
+  } catch {
+    // Offline fallback: read localStorage meta
+    try {
+      const meta = JSON.parse(localStorage.getItem('skillnote:collections-meta') || '{}')
+      for (const name of Object.keys(meta)) set.add(name)
+    } catch {}
+  }
   return Array.from(set).sort((a, b) => a.localeCompare(b))
 }
 
@@ -41,7 +50,9 @@ export function CollectionPicker({ selected, onChange, placeholder, compact = fa
   const searchRef = useRef<HTMLInputElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => { setAllCollections(getAllCollections()) }, [])
+  useEffect(() => {
+    getAllCollectionsAsync().then(setAllCollections)
+  }, [])
 
   // Focus search input whenever dropdown opens
   useEffect(() => {
@@ -83,13 +94,21 @@ export function CollectionPicker({ selected, onChange, placeholder, compact = fa
   // Flat ordered list of items for keyboard navigation
   const items: string[] = [...filtered, ...(canCreate ? ['__create__'] : [])]
 
-  function add(item: string) {
+  async function add(item: string) {
     const name = item === '__create__' ? query.trim() : item
     if (!name) return
     if (!selected.some(c => c.toLowerCase() === name.toLowerCase())) {
       onChange([...selected, name])
-      persistCollection(name)
-      setAllCollections(getAllCollections())
+      if (item === '__create__') {
+        try {
+          await createCollectionApi(name, '')
+        } catch {
+          // Offline fallback: store locally
+          persistCollection(name)
+        }
+        const fresh = await getAllCollectionsAsync()
+        setAllCollections(fresh)
+      }
     }
     setOpen(false)
   }

--- a/src/components/collections/NewCollectionModal.tsx
+++ b/src/components/collections/NewCollectionModal.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 import { FolderOpen, Plus, X, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
+import { createCollectionApi } from '@/lib/api/collections'
 
 type Props = { onClose: () => void; onCreated: (name: string, description: string) => void }
 
@@ -20,16 +21,29 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
     return () => document.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  function handleCreate() {
+  async function handleCreate() {
     if (!name.trim()) { setNameError('Name is required'); nameRef.current?.focus(); return }
     setNameError('')
     setSaving(true)
     try {
-      const meta = JSON.parse(localStorage.getItem('skillnote:collections-meta') || '{}')
-      meta[name.trim()] = { description: description.trim(), created_at: new Date().toISOString() }
-      localStorage.setItem('skillnote:collections-meta', JSON.stringify(meta))
-      onCreated(name.trim(), description.trim())
-      toast.success(`Collection "${name.trim()}" created`)
+      const trimmedName = name.trim()
+      const trimmedDesc = description.trim()
+      try {
+        await createCollectionApi(trimmedName, trimmedDesc)
+      } catch (err) {
+        // Fallback: keep local-only entry so user doesn't lose their work if offline
+        try {
+          const meta = JSON.parse(localStorage.getItem('skillnote:collections-meta') || '{}')
+          meta[trimmedName] = { description: trimmedDesc, created_at: new Date().toISOString() }
+          localStorage.setItem('skillnote:collections-meta', JSON.stringify(meta))
+        } catch {}
+        toast.error(err instanceof Error ? err.message : 'Could not create collection on server — saved locally')
+        onCreated(trimmedName, trimmedDesc)
+        onClose()
+        return
+      }
+      onCreated(trimmedName, trimmedDesc)
+      toast.success(`Collection "${trimmedName}" created`)
       onClose()
     } finally {
       setSaving(false)

--- a/src/lib/api/collections.ts
+++ b/src/lib/api/collections.ts
@@ -1,0 +1,44 @@
+import { apiRequest } from './client'
+
+export type CollectionListItem = {
+  name: string
+  count: number
+  description: string
+}
+
+export type CollectionDetail = {
+  name: string
+  description: string
+  created_at: string
+  updated_at: string
+}
+
+export async function fetchCollectionsApi(): Promise<CollectionListItem[]> {
+  return apiRequest<CollectionListItem[]>('/v1/collections')
+}
+
+export async function createCollectionApi(
+  name: string,
+  description: string,
+): Promise<CollectionDetail> {
+  return apiRequest<CollectionDetail>('/v1/collections', {
+    method: 'POST',
+    body: JSON.stringify({ name, description }),
+  })
+}
+
+export async function updateCollectionApi(
+  name: string,
+  description: string,
+): Promise<CollectionDetail> {
+  return apiRequest<CollectionDetail>(`/v1/collections/${encodeURIComponent(name)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ description }),
+  })
+}
+
+export async function deleteCollectionApi(name: string): Promise<void> {
+  await apiRequest<void>(`/v1/collections/${encodeURIComponent(name)}`, {
+    method: 'DELETE',
+  })
+}

--- a/src/lib/derived.ts
+++ b/src/lib/derived.ts
@@ -1,4 +1,5 @@
 import { Skill } from './mock-data'
+import type { CollectionListItem } from './api/collections'
 
 export function deriveCollections(skills: Skill[]) {
   const map = new Map<string, { count: number; updatedAt: string }>()
@@ -30,4 +31,26 @@ export function deriveCollections(skills: Skill[]) {
       updated_at: updatedAt,
     }
   })
+}
+
+export function deriveCollectionsFromApi(
+  skills: Skill[],
+  apiCollections: CollectionListItem[],
+) {
+  // Build map of "most recent updatedAt" per collection from skills
+  const updatedAtBySkill = new Map<string, string>()
+  for (const s of skills) {
+    for (const c of s.collections || []) {
+      const cur = updatedAtBySkill.get(c)
+      if (!cur || s.updated_at > cur) updatedAtBySkill.set(c, s.updated_at)
+    }
+  }
+
+  return apiCollections.map((c, i) => ({
+    id: String(i + 1),
+    name: c.name,
+    description: c.description || `${c.name} skills`,
+    skill_count: c.count,
+    updated_at: updatedAtBySkill.get(c.name) || new Date(0).toISOString(),
+  }))
 }


### PR DESCRIPTION
## Summary
- Promotes collections from localStorage-only strings to a first-class DB entity with full CRUD API
- Empty collections now appear in the CLI picker (`skillnote-pick`) at session start
- Auto-migrates existing localStorage-meta entries to the API on first load of `/collections`

## Root cause

The CLI picker fetches `/v1/collections`, which was implemented as `SELECT unnest(collections) FROM skills ... GROUP BY name` — meaning a collection only surfaced via the API once ≥1 skill referenced it. `NewCollectionModal` wrote only to browser localStorage, so newly-created empty collections were invisible to the CLI picker no matter how many times users restarted. Adding one skill would suddenly make the collection appear.

## What changed

**Backend (8 commits):**
- Migration `0011_collections_table`: new `collections` table keyed by `name`, with `description` + timestamps
- `Collection` SQLAlchemy model + `CollectionCreate/Update/Detail/ListItem` Pydantic schemas
- `validate_collection_name` — free-form text (to preserve `"lp assessment"`), max 128 chars, non-empty, no newlines/XML
- `GET /v1/collections` now UNIONs skill-derived names with empty rows from the table; response gains an additive `description` field (CLI keeps working)
- `POST /v1/collections` (409 on duplicate), `PUT /v1/collections/{name}` (description-only; no rename in 0.3.1), `DELETE /v1/collections/{name}` (409 if any skill still references it)

**Frontend (4 commits):**
- `src/lib/api/collections.ts` — typed API client
- `NewCollectionModal` POSTs to the API, falling back to localStorage + error toast on network failure
- `/collections` page reads from the API and auto-migrates stale `skillnote:collections-meta` entries (POST missing ones, then clear on success; retry next page load on partial failure)
- Inline `CollectionPicker` (skill editor) fetches from the API with localStorage fallback

## Test plan
- [x] `pytest tests/unit/test_collection_validator.py` — 8/8 passing
- [x] `pytest tests/integration/test_collections_api.py` — 11/11 passing (covers shape, POST + dup + validation + whitespace, PUT + 404, DELETE + 404 + 409 skill-ref)
- [x] API smoke: POST empty collection → appears in GET with `count: 0, description` → CLI picker's `fetch_collections()` sees it → DELETE returns 204
- [x] `npx tsc --noEmit` — no new errors in `src/**` (pre-existing `cli/**` errors unrelated)
- [ ] UI smoke: create empty collection in web UI on a deployed build → appears in CLI picker at next `claude` session start (requires rebuilding the web container; recommended as a deploy step)

## Notes
- No auth changes (still disabled per migration 0004)
- No rename support in 0.3.1 (YAGNI — PUT updates description only)
- `deriveCollections()` in `src/lib/derived.ts` preserved for now; `deriveCollectionsFromApi()` added alongside

🤖 Generated with [Claude Code](https://claude.com/claude-code)