### PR TITLE
feat: collection picker — Create / Skip / (Recommended) + validation hardening + UX polish

### DIFF
--- a/backend/alembic/versions/0012_slugify_collection_names.py
+++ b/backend/alembic/versions/0012_slugify_collection_names.py
@@ -1,0 +1,95 @@
+"""slugify collection names
+
+Revision ID: 0012_slugify_collection_names
+Revises: 0011_collections_table
+Create Date: 2026-04-18
+"""
+import hashlib
+import re
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0012_slugify_collection_names'
+down_revision = '0011_collections_table'
+branch_labels = None
+depends_on = None
+
+
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+MAX_LEN = 128
+
+
+def _slugify(name: str) -> str:
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9_-]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    s = s.strip("-")
+    return s[:MAX_LEN]
+
+
+def _fallback(original: str) -> str:
+    return f"collection-{hashlib.sha1(original.encode('utf-8')).hexdigest()[:8]}"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Gather every distinct collection name (union of collections table + skills embedded arrays)
+    rows = conn.execute(sa.text(
+        """
+        SELECT name, created_at FROM (
+            SELECT name, created_at FROM collections
+            UNION
+            SELECT DISTINCT unnest(collections) AS name, now() AS created_at
+            FROM skills
+            WHERE collections IS NOT NULL AND collections != '{}'
+        ) u
+        ORDER BY created_at, name
+        """
+    )).all()
+
+    # 2. Build the rename map with collision resolution
+    rename: dict[str, str] = {}
+    used: set[str] = set()
+    for name, _created in rows:
+        if NAME_PATTERN.match(name) and len(name) <= MAX_LEN:
+            used.add(name)
+            continue
+        candidate = _slugify(name) or _fallback(name)
+        if candidate in used:
+            base = candidate
+            i = 2
+            while f"{base}-{i}" in used:
+                i += 1
+            candidate = f"{base}-{i}"
+        rename[name] = candidate
+        used.add(candidate)
+
+    if not rename:
+        return  # idempotent no-op
+
+    # 3. Rename collections table rows atomically using a VALUES-based UPDATE
+    pairs = list(rename.items())
+    values_sql = ", ".join(f"(:old_{i}, :new_{i})" for i in range(len(pairs)))
+    params = {}
+    for i, (old, new) in enumerate(pairs):
+        params[f"old_{i}"] = old
+        params[f"new_{i}"] = new
+    conn.execute(sa.text(
+        f"UPDATE collections SET name = m.new_name, updated_at = now() "
+        f"FROM (VALUES {values_sql}) AS m(old_name, new_name) "
+        f"WHERE collections.name = m.old_name"
+    ), params)
+
+    # 4. Rewrite skill.collections arrays — apply each rename pair
+    for old, new in pairs:
+        conn.execute(sa.text(
+            "UPDATE skills SET collections = array_replace(collections, :old, :new) "
+            "WHERE :old = ANY(collections)"
+        ), {"old": old, "new": new})
+
+
+def downgrade() -> None:
+    # Cannot recover original casing/punctuation without a pre-migration stash
+    pass

--- a/backend/alembic/versions/0012_slugify_collection_names.py
+++ b/backend/alembic/versions/0012_slugify_collection_names.py
@@ -48,6 +48,42 @@ def _clamp_with_suffix(base: str, suffix: str) -> str:
     return truncated + suffix
 
 
+def _build_rename_map(rows):
+    """Given a list of (name, created_at) tuples (ordered deterministically by
+    the caller), return dict[old_name -> new_name] for rows that need renaming.
+
+    Invariant: every already-valid name is reserved in `used` BEFORE collision
+    resolution runs, so a collision-resolved `-N` suffix can never clobber a
+    pre-existing valid slug.
+    """
+    # First pass: reserve EVERY already-valid name
+    used: set[str] = {
+        name for name, _created in rows
+        if NAME_PATTERN.match(name) and len(name) <= MAX_LEN
+    }
+
+    # Second pass: slugify + collision-resolve the invalid names only
+    rename: dict[str, str] = {}
+    for name, _created in rows:
+        if name in used:
+            continue  # already a valid slug
+        candidate = _slugify(name) or _fallback(name)
+        # Clamp candidate so the stored name and every `-N` variant fits in MAX_LEN chars.
+        candidate = _clamp_with_suffix(candidate, "")
+        if candidate in used:
+            base = candidate
+            i = 2
+            while True:
+                suffixed = _clamp_with_suffix(base, f"-{i}")
+                if suffixed not in used:
+                    candidate = suffixed
+                    break
+                i += 1
+        rename[name] = candidate
+        used.add(candidate)
+    return rename
+
+
 def upgrade() -> None:
     conn = op.get_bind()
 
@@ -65,34 +101,8 @@ def upgrade() -> None:
         """
     )).all()
 
-    # 2. Build the rename map with collision resolution.
-    # First pass: reserve EVERY already-valid name so later collision resolution
-    # cannot clobber a pre-existing valid slug.
-    used: set[str] = {
-        name for name, _created in rows
-        if NAME_PATTERN.match(name) and len(name) <= MAX_LEN
-    }
-
-    # Second pass: slugify + collision-resolve the invalid names only.
-    rename: dict[str, str] = {}
-    for name, _created in rows:
-        if name in used:
-            continue  # already a valid slug — no rename needed
-        candidate = _slugify(name) or _fallback(name)
-        # Clamp candidate to MAX_LEN before collision check (see I1)
-        candidate = _clamp_with_suffix(candidate, "")
-        if candidate in used:
-            base = candidate
-            i = 2
-            while True:
-                suffixed = _clamp_with_suffix(base, f"-{i}")
-                if suffixed not in used:
-                    candidate = suffixed
-                    break
-                i += 1
-        rename[name] = candidate
-        used.add(candidate)
-
+    # 2. Build the rename map (see _build_rename_map docstring for invariants)
+    rename = _build_rename_map(rows)
     if not rename:
         return  # idempotent no-op
 

--- a/backend/alembic/versions/0012_slugify_collection_names.py
+++ b/backend/alembic/versions/0012_slugify_collection_names.py
@@ -3,6 +3,14 @@
 Revision ID: 0012_slugify_collection_names
 Revises: 0011_collections_table
 Create Date: 2026-04-18
+
+Key invariant: all valid names are reserved in ``used`` BEFORE any collision
+resolution begins, so a collision-resolved ``-N`` suffix can never clobber a
+pre-existing valid slug. Additionally, every candidate (base and any
+``-N``-suffixed variant) is clamped via ``_clamp_with_suffix`` so the final
+rewritten name always fits in ``MAX_LEN`` — preserving the bound checked by
+the post-migration smoke test (``test_collection_names_are_bounded``) and any
+future validator call.
 """
 import hashlib
 import re
@@ -32,6 +40,14 @@ def _fallback(original: str) -> str:
     return f"collection-{hashlib.sha1(original.encode('utf-8')).hexdigest()[:8]}"
 
 
+def _clamp_with_suffix(base: str, suffix: str) -> str:
+    """Truncate base so that base + suffix fits in MAX_LEN. Strip trailing '-'
+    after truncation so we don't leave '---2'."""
+    max_base = MAX_LEN - len(suffix)
+    truncated = base[:max_base].rstrip("-")
+    return truncated + suffix
+
+
 def upgrade() -> None:
     conn = op.get_bind()
 
@@ -49,20 +65,31 @@ def upgrade() -> None:
         """
     )).all()
 
-    # 2. Build the rename map with collision resolution
+    # 2. Build the rename map with collision resolution.
+    # First pass: reserve EVERY already-valid name so later collision resolution
+    # cannot clobber a pre-existing valid slug.
+    used: set[str] = {
+        name for name, _created in rows
+        if NAME_PATTERN.match(name) and len(name) <= MAX_LEN
+    }
+
+    # Second pass: slugify + collision-resolve the invalid names only.
     rename: dict[str, str] = {}
-    used: set[str] = set()
     for name, _created in rows:
-        if NAME_PATTERN.match(name) and len(name) <= MAX_LEN:
-            used.add(name)
-            continue
+        if name in used:
+            continue  # already a valid slug — no rename needed
         candidate = _slugify(name) or _fallback(name)
+        # Clamp candidate to MAX_LEN before collision check (see I1)
+        candidate = _clamp_with_suffix(candidate, "")
         if candidate in used:
             base = candidate
             i = 2
-            while f"{base}-{i}" in used:
+            while True:
+                suffixed = _clamp_with_suffix(base, f"-{i}")
+                if suffixed not in used:
+                    candidate = suffixed
+                    break
                 i += 1
-            candidate = f"{base}-{i}"
         rename[name] = candidate
         used.add(candidate)
 

--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -17,6 +17,7 @@ from app.validators.skill_validator import (
     canonicalize_collection_names,
     validate_collection_skill_count,
 )
+from app.validators.collection_validator import validate_collection_name
 
 router = APIRouter(prefix="/v1/skills", tags=["skills"])
 
@@ -303,6 +304,13 @@ def create_skill(
 
     # Canonicalize: map case variants to existing stored forms, de-duplicate
     canonical_collections = canonicalize_collection_names(db, payload.collections or [])
+
+    # Validate each canonical name against the shared collection-name rule
+    for col_name in canonical_collections:
+        name_errs = validate_collection_name(col_name)
+        if name_errs:
+            raise api_error(422, "COLLECTION_NAME_INVALID",
+                            f'Collection "{col_name}": {"; ".join(name_errs)}')
 
     # Check collection skill-count limits
     for col_name in canonical_collections:

--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -312,6 +312,23 @@ def create_skill(
             raise api_error(422, "COLLECTION_NAME_INVALID",
                             f'Collection "{col_name}": {"; ".join(name_errs)}')
 
+    # Auto-promote: ensure every referenced collection has a row in the
+    # `collections` table so detail/PUT/DELETE endpoints can reach it.
+    # (Without this, a skill can implicitly create a name that is listed via
+    #  GET /v1/collections but 404s on GET /v1/collections/{name}.)
+    if canonical_collections:
+        db.execute(
+            text(
+                "INSERT INTO collections (name, description, created_at, updated_at) "
+                "SELECT n.name, '', now(), now() "
+                "FROM unnest(CAST(:names AS text[])) AS n(name) "
+                "WHERE NOT EXISTS ("
+                "    SELECT 1 FROM collections c WHERE lower(c.name) = lower(n.name)"
+                ")"
+            ),
+            {"names": canonical_collections},
+        )
+
     # Check collection skill-count limits
     for col_name in canonical_collections:
         err = validate_collection_skill_count(db, col_name)
@@ -383,6 +400,22 @@ def update_skill(
             if name_errs:
                 raise api_error(422, "COLLECTION_NAME_INVALID",
                                 f'Collection "{col_name}": {"; ".join(name_errs)}')
+        # Auto-promote: ensure every referenced collection has a row in the
+        # `collections` table so detail/PUT/DELETE endpoints can reach it.
+        # (Without this, a skill can implicitly create a name that is listed via
+        #  GET /v1/collections but 404s on GET /v1/collections/{name}.)
+        if canonical_collections:
+            db.execute(
+                text(
+                    "INSERT INTO collections (name, description, created_at, updated_at) "
+                    "SELECT n.name, '', now(), now() "
+                    "FROM unnest(CAST(:names AS text[])) AS n(name) "
+                    "WHERE NOT EXISTS ("
+                    "    SELECT 1 FROM collections c WHERE lower(c.name) = lower(n.name)"
+                    ")"
+                ),
+                {"names": canonical_collections},
+            )
         # Check skill-count limits for any newly added collections (case-insensitive)
         current_lower = {c.lower() for c in (skill_row.collections or [])}
         for col_name in canonical_collections:

--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -377,6 +377,12 @@ def update_skill(
     if payload.collections is not None:
         # Canonicalize incoming names to stored case + de-duplicate variants
         canonical_collections = canonicalize_collection_names(db, payload.collections)
+        # Validate each canonical name against the shared rule
+        for col_name in canonical_collections:
+            name_errs = validate_collection_name(col_name)
+            if name_errs:
+                raise api_error(422, "COLLECTION_NAME_INVALID",
+                                f'Collection "{col_name}": {"; ".join(name_errs)}')
         # Check skill-count limits for any newly added collections (case-insensitive)
         current_lower = {c.lower() for c in (skill_row.collections or [])}
         for col_name in canonical_collections:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -46,6 +47,35 @@ async def http_exception_handler(_: Request, exc: HTTPException):
     else:
         payload = {"code": "HTTP_ERROR", "message": str(detail)}
     return JSONResponse(status_code=exc.status_code, content={"error": payload})
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(_: Request, exc: RequestValidationError):
+    """Wrap Pydantic/FastAPI validation errors in the standard error envelope.
+
+    Without this handler, FastAPI returns `{"detail": [...]}`, which (a) breaks
+    the frontend error-parsing contract (`body.error.message`), (b) echoes the
+    raw user input back as `input` fields, and (c) leaks internal `ctx` keys.
+    """
+    errors = exc.errors()
+    # Build a human-readable message from the first (or joined) errors.
+    # Strip Pydantic-internal fields (`input`, `ctx`, `url`) before stringifying.
+    messages = []
+    for err in errors:
+        loc = " → ".join(str(p) for p in err.get("loc", ()) if p != "body")
+        msg = err.get("msg", "invalid")
+        # Pydantic wraps custom ValueErrors as "Value error, <real message>" — strip the prefix
+        if msg.startswith("Value error, "):
+            msg = msg[len("Value error, "):]
+        if loc:
+            messages.append(f"{loc}: {msg}")
+        else:
+            messages.append(msg)
+    message = "; ".join(messages) if messages else "Validation failed"
+    return JSONResponse(
+        status_code=422,
+        content={"error": {"code": "VALIDATION_ERROR", "message": message}},
+    )
 
 
 @app.exception_handler(Exception)

--- a/backend/app/schemas/collection.py
+++ b/backend/app/schemas/collection.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel, field_validator
 
-from app.validators.collection_validator import validate_collection_name
+from app.validators.collection_validator import XML_TAG_RE, validate_collection_name
 
 
 class CollectionListItem(BaseModel):
@@ -31,6 +31,8 @@ class CollectionCreate(BaseModel):
             return ""
         if len(v) > 1024:
             raise ValueError("Description must be 1024 characters or fewer")
+        if XML_TAG_RE.search(v):
+            raise ValueError("Description cannot contain XML tags")
         return v.strip()
 
 
@@ -44,6 +46,8 @@ class CollectionUpdate(BaseModel):
             return ""
         if len(v) > 1024:
             raise ValueError("Description must be 1024 characters or fewer")
+        if XML_TAG_RE.search(v):
+            raise ValueError("Description cannot contain XML tags")
         return v.strip()
 
 

--- a/backend/app/validators/collection_validator.py
+++ b/backend/app/validators/collection_validator.py
@@ -1,6 +1,9 @@
 import re
 
+from app.validators.skill_validator import RESERVED_WORDS
+
 COLLECTION_NAME_MAX = 128
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
 XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
 
 
@@ -17,6 +20,11 @@ def validate_collection_name(name: str) -> list[str]:
         errors.append(f"Collection name must be {COLLECTION_NAME_MAX} characters or fewer")
     if "\n" in stripped or "\r" in stripped:
         errors.append("Collection name cannot contain newlines")
+    if not NAME_PATTERN.match(stripped):
+        errors.append("Collection name must contain only lowercase letters, numbers, hyphens, and underscores")
+    for word in RESERVED_WORDS:
+        if word in stripped:
+            errors.append(f'Collection name cannot contain reserved word "{word}"')
     if XML_TAG_RE.search(stripped):
         errors.append("Collection name cannot contain XML tags")
     return errors

--- a/backend/scripts/seed_data.py
+++ b/backend/scripts/seed_data.py
@@ -99,9 +99,9 @@ def seed_skill(db, slug: str, name: str, description: str, content_md: str, coll
 def seed_collections(db):
     """Explicitly create collection rows. Idempotent — skips existing names."""
     seeds = [
-        ("Official", "Skills curated by the SkillNote team."),
-        ("Conventions", "Team coding conventions and best practices."),
-        ("DevOps", "Deployment, infrastructure, and release workflows."),
+        ("official", "Skills curated by the SkillNote team."),
+        ("conventions", "Team coding conventions and best practices."),
+        ("devops", "Deployment, infrastructure, and release workflows."),
     ]
     for name, description in seeds:
         exists = db.execute(
@@ -139,7 +139,7 @@ def main():
                 name="skill-creator",
                 description=fm.get("description", "Create new skills, modify and improve existing skills, and measure skill performance."),
                 content_md=body,
-                collections=["Official"],
+                collections=["official"],
             )
 
         # 2. Skill Push (from seeds/ file)
@@ -153,7 +153,7 @@ def main():
                 name="skill-push",
                 description=fm.get("description", "Create and push skills to the SkillNote registry."),
                 content_md=body,
-                collections=["Official"],
+                collections=["official"],
             )
 
         # 3. Secure Migrations (existing seed)
@@ -163,7 +163,7 @@ def main():
             name="secure-migrations",
             description="DB migration safety checklist",
             content_md="# Secure Migrations\n\nA checklist for safely deploying database migrations in production.\n\n## Before You Migrate\n\n- Review backwards compatibility\n- Test the migration on staging first\n- Have a rollback plan (down migration or snapshot)\n- Communicate planned downtime if schema locks are expected\n\n## Running the Migration\n\n```bash\n# Always dry-run first\nalembic upgrade head --sql | less\n\n# Apply\nalembic upgrade head\n```\n\n## After Migration\n\n- Verify row counts on critical tables\n- Run smoke tests against the updated schema\n- Monitor error rates for 15 minutes post-deploy",
-            collections=["DevOps"],
+            collections=["devops"],
         )
 
         # 4. Code Review Checklist
@@ -173,7 +173,7 @@ def main():
             name="code-review-checklist",
             description="Structured code review checklist. Trigger when: review, PR, pull request, code review, feedback.",
             content_md="# Code Review Checklist\n\nWhen reviewing a pull request, check:\n\n## Correctness\n- Does the code do what it claims?\n- Are edge cases handled?\n- Are there off-by-one errors?\n\n## Security\n- No hardcoded secrets or API keys\n- Input validation on user data\n- SQL injection / XSS prevention\n\n## Performance\n- No N+1 queries\n- No unnecessary re-renders\n- Pagination for large lists\n\n## Readability\n- Clear variable/function names\n- No overly clever one-liners\n- Comments explain WHY, not WHAT\n\n## Tests\n- New code has tests\n- Edge cases covered\n- Tests actually assert something meaningful",
-            collections=["Conventions"],
+            collections=["conventions"],
         )
 
         # 5. Git Commit Convention
@@ -183,7 +183,7 @@ def main():
             name="git-commit-convention",
             description="Conventional commit message format. Trigger when: commit, git commit, commit message, conventional commits.",
             content_md="# Git Commit Convention\n\nUse Conventional Commits format:\n\n```\n<type>(<scope>): <description>\n\n[optional body]\n[optional footer]\n```\n\n## Types\n- `feat`: New feature\n- `fix`: Bug fix\n- `docs`: Documentation only\n- `style`: Formatting, no code change\n- `refactor`: Code restructuring\n- `test`: Adding tests\n- `chore`: Maintenance\n\n## Rules\n- Subject line max 72 chars\n- Use imperative mood (\"add\" not \"added\")\n- No period at the end\n- Body explains WHY, not WHAT\n- Reference issues: `Fixes #123`",
-            collections=["Conventions"],
+            collections=["conventions"],
         )
 
         # 6. Error Handling Pattern
@@ -193,7 +193,7 @@ def main():
             name="error-handling",
             description="Standard error handling patterns. Trigger when: error, exception, try catch, error handling, error boundary.",
             content_md="# Error Handling\n\n## Backend (Python)\n- Use specific exception types, not bare `except:`\n- Log errors with context (user ID, request ID)\n- Return structured errors: `{\"error\": {\"code\": \"...\", \"message\": \"...\"}}`\n- Never expose stack traces to clients\n\n## Frontend (React)\n- Use Error Boundaries for component trees\n- Handle loading/error/success states explicitly\n- Show user-friendly messages, log technical details\n- Use `toast.error()` for transient errors\n\n## API Calls\n- Always handle network errors\n- Implement retry with exponential backoff for transient failures\n- Set timeouts on all HTTP requests\n- Validate response shape before using",
-            collections=["Conventions"],
+            collections=["conventions"],
         )
 
         # 7. Testing Guide
@@ -203,7 +203,7 @@ def main():
             name="testing-guide",
             description="Testing best practices and patterns. Trigger when: test, testing, unit test, integration test, write tests.",
             content_md="# Testing Guide\n\n## Unit Tests\n- Test one thing per test\n- Name tests: `test_<what>_<condition>_<expected>`\n- Use arrange-act-assert pattern\n- Mock external dependencies, not internal logic\n\n## Integration Tests\n- Test the API contract, not implementation\n- Use a real database (not mocks) for DB tests\n- Clean up test data after each test\n\n## What to Test\n- Happy path\n- Edge cases (empty, null, max length)\n- Error paths (invalid input, network failure)\n- Authorization (can't access other user's data)\n\n## What NOT to Test\n- Framework internals\n- Third-party library behavior\n- Exact UI pixel layout",
-            collections=["Conventions"],
+            collections=["conventions"],
         )
 
         # 8. Docker Deploy
@@ -213,7 +213,7 @@ def main():
             name="docker-deploy",
             description="Docker deployment checklist. Trigger when: deploy, docker, container, production, ship.",
             content_md="# Docker Deploy\n\n## Pre-Deploy\n- [ ] All tests pass locally\n- [ ] Environment variables set in production\n- [ ] Database migrations tested on staging\n- [ ] Health check endpoint responds\n\n## Deploy\n```bash\ndocker compose pull\ndocker compose up -d\n```\n\n## Post-Deploy\n- [ ] Health check passes: `curl /health`\n- [ ] Smoke test critical flows\n- [ ] Monitor error rates for 15 minutes\n- [ ] Check logs: `docker compose logs -f`\n\n## Rollback\n```bash\ndocker compose down\ngit checkout <previous-tag>\ndocker compose up -d\n```",
-            collections=["DevOps"],
+            collections=["devops"],
         )
 
         db.commit()

--- a/backend/tests/integration/test_collections_api.py
+++ b/backend/tests/integration/test_collections_api.py
@@ -149,17 +149,16 @@ def test_delete_409_when_skills_reference(unique_name):
 
 # ── Case-insensitive uniqueness ──────────────────────────────────────────────
 
-def test_duplicate_case_variant_rejected(unique_name):
-    """POSTing two case-variant names must fail with 409."""
-    mixed_case = unique_name.upper()
-    status, _ = _request("POST", "/v1/collections", {"name": unique_name, "description": ""})
-    assert status == 201
+def test_post_rejects_uppercase_name(unique_name):
+    """POST with an uppercase name must fail validation with 422.
 
-    status, body = _request("POST", "/v1/collections", {"name": mixed_case, "description": ""})
-    assert status == 409
-    assert body["error"]["code"] == "COLLECTION_EXISTS"
-
-    _request("DELETE", f"/v1/collections/{unique_name}")
+    The stricter name rule (`^[a-z0-9_-]+$`) means uppercase variants can no
+    longer be created at all; case-insensitive dedup only applies on lookup.
+    """
+    status, body = _request(
+        "POST", "/v1/collections", {"name": unique_name.upper(), "description": ""}
+    )
+    assert status == 422, f"expected 422, got {status}: {body}"
 
 
 def test_get_single_collection_case_insensitive(unique_name):

--- a/backend/tests/integration/test_collections_api.py
+++ b/backend/tests/integration/test_collections_api.py
@@ -279,3 +279,28 @@ def test_get_single_collection_not_found():
     status, body = _request("GET", "/v1/collections/does-not-exist-xyz-12345")
     assert status == 404
     assert body["error"]["code"] == "COLLECTION_NOT_FOUND"
+
+
+# ── XML/XSS rejection in description ─────────────────────────────────────────
+
+def test_post_rejects_xml_in_description(unique_name):
+    status, body = _request("POST", "/v1/collections", {"name": unique_name, "description": "<script>alert(1)</script>"})
+    assert status == 422, f"Expected 422, got {status}: {body}"
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert "xml" in body["error"]["message"].lower() or "tag" in body["error"]["message"].lower()
+
+
+def test_post_accepts_plain_description(unique_name):
+    status, body = _request("POST", "/v1/collections", {"name": unique_name, "description": "A plain description"})
+    assert status == 201, f"Expected 201, got {status}: {body}"
+    assert body["description"] == "A plain description"
+    _request("DELETE", f"/v1/collections/{unique_name}")
+
+
+def test_put_rejects_xml_in_description(unique_name):
+    # Create first
+    _request("POST", "/v1/collections", {"name": unique_name, "description": "ok"})
+    status, body = _request("PUT", f"/v1/collections/{unique_name}", {"description": "<img src=x onerror=alert(1)>"})
+    assert status == 422, f"Expected 422, got {status}: {body}"
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    _request("DELETE", f"/v1/collections/{unique_name}")

--- a/backend/tests/integration/test_migration_0012_slugify.py
+++ b/backend/tests/integration/test_migration_0012_slugify.py
@@ -1,0 +1,36 @@
+"""Post-migration smoke test for 0012.
+
+Verifies that after the backend starts (which runs `alembic upgrade head`
+per the Dockerfile), every collection name returned by /v1/collections
+matches the new regex. Skips if API unreachable.
+"""
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+
+import pytest
+
+BASE_URL = os.environ.get("SKILLNOTE_TEST_BASE_URL", "http://127.0.0.1:8082")
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+
+def _get_collections():
+    try:
+        with urllib.request.urlopen(f"{BASE_URL}/v1/collections") as r:
+            return json.loads(r.read())
+    except Exception as e:
+        pytest.skip(f"API not reachable: {e}")
+
+
+def test_all_collection_names_are_valid_slugs():
+    cols = _get_collections()
+    bad = [c["name"] for c in cols if not NAME_PATTERN.match(c["name"])]
+    assert not bad, f"Non-slug collection names still present after migration: {bad}"
+
+
+def test_collection_names_are_bounded():
+    cols = _get_collections()
+    over = [c["name"] for c in cols if len(c["name"]) > 128]
+    assert not over, f"Names over 128 chars: {over}"

--- a/backend/tests/integration/test_skills_api.py
+++ b/backend/tests/integration/test_skills_api.py
@@ -34,14 +34,17 @@ def _request(method: str, path: str, body: dict | None = None):
 
 @pytest.fixture
 def seed_collection():
-    name = "frontend"
-    _request("POST", "/v1/collections", {"name": name, "description": ""})  # ignore 409 if already exists
+    name = f"seed-{uuid.uuid4().hex[:8]}"
+    _request("POST", "/v1/collections", {"name": name, "description": ""})
     yield name
+    _request("DELETE", f"/v1/collections/{name}")
 
 
 @pytest.fixture
 def unique_skill_slug():
-    return f"test-skill-{uuid.uuid4().hex[:8]}"
+    slug = f"test-skill-{uuid.uuid4().hex[:8]}"
+    yield slug
+    _request("DELETE", f"/v1/skills/{slug}")  # idempotent — 404 is fine
 
 
 def _skill_payload(slug: str, collections: list[str]):
@@ -61,18 +64,17 @@ def test_create_skill_rejects_invalid_collection_name(seed_collection, unique_sk
 
 
 def test_create_skill_accepts_canonicalizable_variant(seed_collection, unique_skill_slug):
-    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["Frontend"]))
+    # Send uppercase variant; canonicalize should map it to the seeded lowercase form
+    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, [seed_collection.upper()]))
     assert status == 201, body
-    assert body["collections"] == ["frontend"]
-    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+    assert body["collections"] == [seed_collection]
 
 
 def test_update_skill_rejects_invalid_collection_name(seed_collection, unique_skill_slug):
-    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["frontend"]))
+    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, [seed_collection]))
     assert status == 201
     status, body = _request(
         "PATCH", f"/v1/skills/{unique_skill_slug}", {"collections": ["Bad Name"]}
     )
     assert status == 422
     assert body["error"]["code"] == "COLLECTION_NAME_INVALID"
-    _request("DELETE", f"/v1/skills/{unique_skill_slug}")

--- a/backend/tests/integration/test_skills_api.py
+++ b/backend/tests/integration/test_skills_api.py
@@ -1,0 +1,78 @@
+"""Integration tests for skill-create/update collection-name validation.
+
+Requires a running backend on 127.0.0.1:8082 (`docker compose up api`).
+Tests skip if API unreachable.
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+BASE_URL = os.environ.get("SKILLNOTE_TEST_BASE_URL", "http://127.0.0.1:8082")
+
+
+def _request(method: str, path: str, body: dict | None = None):
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        method=method,
+        headers={"Content-Type": "application/json"} if body else {},
+        data=(json.dumps(body).encode() if body is not None else None),
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            text = r.read().decode()
+            return r.status, json.loads(text) if text else None
+    except urllib.error.HTTPError as e:
+        text = e.read().decode()
+        return e.code, json.loads(text) if text else None
+    except Exception as e:
+        pytest.skip(f"API not reachable: {e}")
+
+
+@pytest.fixture
+def seed_collection():
+    name = "frontend"
+    _request("POST", "/v1/collections", {"name": name, "description": ""})  # ignore 409 if already exists
+    yield name
+
+
+@pytest.fixture
+def unique_skill_slug():
+    return f"test-skill-{uuid.uuid4().hex[:8]}"
+
+
+def _skill_payload(slug: str, collections: list[str]):
+    return {
+        "name": slug,
+        "slug": slug,
+        "description": "validation test skill",
+        "content_md": "",
+        "collections": collections,
+    }
+
+
+def test_create_skill_rejects_invalid_collection_name(seed_collection, unique_skill_slug):
+    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["Bad Name"]))
+    assert status == 422
+    assert body["error"]["code"] == "COLLECTION_NAME_INVALID"
+
+
+def test_create_skill_accepts_canonicalizable_variant(seed_collection, unique_skill_slug):
+    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["Frontend"]))
+    assert status == 201, body
+    assert body["collections"] == ["frontend"]
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+
+
+def test_update_skill_rejects_invalid_collection_name(seed_collection, unique_skill_slug):
+    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["frontend"]))
+    assert status == 201
+    status, body = _request(
+        "PATCH", f"/v1/skills/{unique_skill_slug}", {"collections": ["Bad Name"]}
+    )
+    assert status == 422
+    assert body["error"]["code"] == "COLLECTION_NAME_INVALID"
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")

--- a/backend/tests/integration/test_skills_api.py
+++ b/backend/tests/integration/test_skills_api.py
@@ -78,3 +78,77 @@ def test_update_skill_rejects_invalid_collection_name(seed_collection, unique_sk
     )
     assert status == 422
     assert body["error"]["code"] == "COLLECTION_NAME_INVALID"
+
+
+def test_create_skill_auto_promotes_new_collection(unique_skill_slug):
+    """A skill created with a collection name that doesn't have a row
+    should trigger an INSERT into collections so the collection is
+    reachable via GET /v1/collections/{name}."""
+    new_col = f"autopromote-{uuid.uuid4().hex[:8]}"
+
+    # Verify collection doesn't exist yet
+    status, _ = _request("GET", f"/v1/collections/{new_col}")
+    assert status == 404, f"Precondition failed: {new_col} should not exist"
+
+    # Create skill referencing it
+    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, [new_col]))
+    assert status == 201
+
+    # Collection should now be editable
+    status, body = _request("GET", f"/v1/collections/{new_col}")
+    assert status == 200, f"Expected 200 after auto-promote, got {status}: {body}"
+    assert body["name"] == new_col
+
+    # Cleanup
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+    _request("DELETE", f"/v1/collections/{new_col}")
+
+
+def test_patch_skill_auto_promotes_new_collection(seed_collection, unique_skill_slug):
+    """Adding a collection via PATCH also auto-promotes."""
+    # Create skill with seeded collection
+    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, [seed_collection]))
+    assert status == 201
+
+    # PATCH to add a new collection
+    new_col = f"patch-autopromote-{uuid.uuid4().hex[:8]}"
+    status, _ = _request("GET", f"/v1/collections/{new_col}")
+    assert status == 404
+
+    status, _ = _request("PATCH", f"/v1/skills/{unique_skill_slug}",
+                         {"collections": [seed_collection, new_col]})
+    assert status == 200
+
+    status, body = _request("GET", f"/v1/collections/{new_col}")
+    assert status == 200, f"Expected 200 after auto-promote on PATCH, got {status}: {body}"
+
+    # Cleanup
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+    _request("DELETE", f"/v1/collections/{new_col}")
+
+
+def test_auto_promoted_collection_has_empty_description(unique_skill_slug):
+    """An auto-promoted collection should have empty description (not NULL)."""
+    new_col = f"desc-test-{uuid.uuid4().hex[:8]}"
+    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, [new_col]))
+    assert status == 201
+
+    status, body = _request("GET", f"/v1/collections/{new_col}")
+    assert status == 200
+    assert body["description"] == ""
+
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+    _request("DELETE", f"/v1/collections/{new_col}")
+
+
+def test_auto_promote_idempotent_on_existing_collection(seed_collection, unique_skill_slug):
+    """If the collection already exists, skill creation shouldn't fail or duplicate."""
+    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, [seed_collection]))
+    assert status == 201
+
+    # Listing should show the collection only once
+    status, cols = _request("GET", "/v1/collections")
+    names = [c["name"] for c in cols]
+    assert names.count(seed_collection) == 1, f"Duplicate entries for {seed_collection}: {names}"
+
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")

--- a/backend/tests/integration/test_validation_envelope.py
+++ b/backend/tests/integration/test_validation_envelope.py
@@ -1,0 +1,71 @@
+"""Integration tests verifying Pydantic 422s are wrapped in the standard error envelope.
+
+Requires a running backend on 127.0.0.1:8082 (`podman-compose up api`).
+Tests skip if API unreachable.
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+
+import pytest
+
+BASE_URL = os.environ.get("SKILLNOTE_TEST_BASE_URL", "http://127.0.0.1:8082")
+
+
+def _post(path: str, body: dict):
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps(body).encode(),
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+    except Exception as e:
+        pytest.skip(f"API not reachable: {e}")
+
+
+def test_collection_validation_422_uses_error_envelope():
+    status, body = _post("/v1/collections", {"name": ""})
+    assert status == 422
+    assert "error" in body, f"Expected 'error' envelope, got: {body}"
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert isinstance(body["error"]["message"], str)
+    assert "required" in body["error"]["message"].lower() or "name" in body["error"]["message"].lower()
+
+
+def test_collection_invalid_name_uses_error_envelope():
+    status, body = _post("/v1/collections", {"name": "Uppercase"})
+    assert status == 422
+    assert "error" in body
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_missing_required_field_uses_error_envelope():
+    # POST with no name key at all
+    status, body = _post("/v1/collections", {"description": "no name"})
+    assert status == 422
+    assert "error" in body
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    assert "name" in body["error"]["message"].lower()
+
+
+def test_envelope_does_not_leak_raw_input():
+    """The envelope should NOT echo the raw input field (Pydantic default leaks it as `input` key)."""
+    status, body = _post("/v1/collections", {"name": "INJECTION_MARKER_XYZ"})
+    assert status == 422
+    # Envelope should have error object, but should not contain the raw value as a separate leak
+    raw = json.dumps(body)
+    # The message might legitimately mention the value, but the envelope shouldn't expose `ctx` or `input` Pydantic internals
+    assert "ctx" not in raw, f"Pydantic internals leaked: {body}"
+
+
+def test_skill_validation_422_uses_error_envelope():
+    status, body = _post("/v1/skills", {"name": "", "slug": "", "description": "", "collections": []})
+    assert status == 422
+    assert "error" in body
+    assert body["error"]["code"] == "VALIDATION_ERROR"

--- a/backend/tests/unit/test_collection_validator.py
+++ b/backend/tests/unit/test_collection_validator.py
@@ -1,10 +1,15 @@
 """Unit tests for collection name validation."""
+import pytest
 from app.validators.collection_validator import validate_collection_name
 
 
 class TestValidateCollectionName:
-    def test_valid_name_with_spaces(self):
-        assert validate_collection_name("lp assessment") == []
+    def test_name_with_spaces_rejected(self):
+        # Spaces are no longer allowed (slug-only: [a-z0-9_-]+)
+        errors = validate_collection_name("lp assessment")
+        assert any(
+            "lowercase" in e.lower() or "letters, numbers" in e for e in errors
+        )
 
     def test_valid_single_word(self):
         assert validate_collection_name("frontend") == []
@@ -31,3 +36,40 @@ class TestValidateCollectionName:
 
     def test_boundary_128_chars_accepted(self):
         assert validate_collection_name("x" * 128) == []
+
+
+def test_valid_slug_lowercase_hyphens_underscores_digits():
+    assert validate_collection_name("frontend") == []
+    assert validate_collection_name("my-app_2") == []
+    assert validate_collection_name("a") == []
+    assert validate_collection_name("a" * 128) == []
+
+
+def test_rejects_uppercase():
+    errs = validate_collection_name("Frontend")
+    assert any("lowercase" in e.lower() or "letters, numbers" in e for e in errs)
+
+
+def test_rejects_space():
+    errs = validate_collection_name("my app")
+    assert len(errs) >= 1
+
+
+def test_rejects_special_chars():
+    errs = validate_collection_name("foo!")
+    assert len(errs) >= 1
+
+
+def test_rejects_over_128_chars():
+    errs = validate_collection_name("a" * 129)
+    assert any("128" in e for e in errs)
+
+
+def test_rejects_reserved_words():
+    assert any("anthropic" in e for e in validate_collection_name("anthropic-stuff"))
+    assert any("claude" in e for e in validate_collection_name("claude-code"))
+
+
+def test_empty_is_rejected():
+    assert validate_collection_name("") != []
+    assert validate_collection_name("   ") != []

--- a/backend/tests/unit/test_migration_0012_slugify_algorithm.py
+++ b/backend/tests/unit/test_migration_0012_slugify_algorithm.py
@@ -1,0 +1,39 @@
+"""Unit tests for the slugify algorithm used by migration 0012."""
+import importlib.util
+import hashlib
+from pathlib import Path
+
+
+def _load():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "alembic" / "versions" / "0012_slugify_collection_names.py"
+    )
+    spec = importlib.util.spec_from_file_location("m0012", path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_slugify_basic():
+    m = _load()
+    assert m._slugify("Frontend") == "frontend"
+    assert m._slugify("lp assessment") == "lp-assessment"
+    assert m._slugify("my-app") == "my-app"
+    assert m._slugify("!!!") == ""
+
+
+def test_slugify_collapses_and_strips():
+    m = _load()
+    assert m._slugify("   --Foo!!Bar--") == "foo-bar"
+
+
+def test_fallback_uses_hash8():
+    m = _load()
+    expected = f"collection-{hashlib.sha1(b'!!!').hexdigest()[:8]}"
+    assert m._fallback("!!!") == expected
+
+
+def test_fallback_deterministic():
+    m = _load()
+    assert m._fallback("xyz") == m._fallback("xyz")

--- a/backend/tests/unit/test_migration_0012_slugify_algorithm.py
+++ b/backend/tests/unit/test_migration_0012_slugify_algorithm.py
@@ -37,3 +37,15 @@ def test_fallback_uses_hash8():
 def test_fallback_deterministic():
     m = _load()
     assert m._fallback("xyz") == m._fallback("xyz")
+
+
+def test_clamp_with_suffix_never_exceeds_max():
+    m = _load()
+    # Base at max length — suffix must fit within 128 total
+    base = "a" * 128
+    assert len(m._clamp_with_suffix(base, "-2")) == 128
+    assert len(m._clamp_with_suffix(base, "-99")) == 128
+    # Short base — no truncation, plain concat
+    assert m._clamp_with_suffix("foo", "-2") == "foo-2"
+    # Base shorter than allowance — suffix appended as-is
+    assert m._clamp_with_suffix("x", "-5") == "x-5"

--- a/backend/tests/unit/test_migration_0012_slugify_algorithm.py
+++ b/backend/tests/unit/test_migration_0012_slugify_algorithm.py
@@ -49,3 +49,47 @@ def test_clamp_with_suffix_never_exceeds_max():
     assert m._clamp_with_suffix("foo", "-2") == "foo-2"
     # Base shorter than allowance — suffix appended as-is
     assert m._clamp_with_suffix("x", "-5") == "x-5"
+
+
+def test_c1_preexisting_valid_slug_not_clobbered():
+    """Regression test: an invalid name whose collision-resolved slug would
+    match a pre-existing valid slug must NOT clobber it."""
+    from datetime import datetime, timedelta, timezone
+    m = _load()
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    rows = [
+        ("Foo!", t0),                         # invalid → slug 'foo'
+        ("bar", t0 + timedelta(days=1)),      # valid, reserved
+        ("Foo@", t0 + timedelta(days=2)),     # invalid → slug 'foo' collides
+        ("foo-2", t0 + timedelta(days=3)),    # valid, MUST be preserved
+    ]
+    rename = m._build_rename_map(rows)
+    assert rename["Foo!"] == "foo"
+    assert rename["Foo@"] == "foo-3"           # skipped 'foo-2' because it's reserved
+    assert "foo-2" not in rename               # pre-existing valid slug not touched
+    assert "bar" not in rename
+
+
+def test_idempotent_on_all_valid():
+    """When every name is already a valid slug, rename map is empty."""
+    from datetime import datetime, timezone
+    m = _load()
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    rows = [("frontend", t0), ("backend", t0), ("devops", t0)]
+    assert m._build_rename_map(rows) == {}
+
+
+def test_clamp_with_suffix_rstrips_trailing_hyphen():
+    m = _load()
+    # Base ending in hyphen after truncation — rstrip leaves 125 chars, plus '-2' = 127
+    assert m._clamp_with_suffix("a" * 125 + "-", "-2") == "a" * 125 + "-2"
+    # Multiple trailing hyphens
+    assert m._clamp_with_suffix("a" * 124 + "---", "-2") == "a" * 124 + "-2"
+
+
+def test_clamp_with_suffix_empty_suffix():
+    m = _load()
+    # Empty suffix — caps base at MAX_LEN
+    assert m._clamp_with_suffix("a" * 150, "") == "a" * 128
+    # Empty suffix with trailing hyphen after truncation — rstrip
+    assert m._clamp_with_suffix("a" * 127 + "-", "") == "a" * 127

--- a/docs/superpowers/plans/2026-04-18-collection-picker-options.md
+++ b/docs/superpowers/plans/2026-04-18-collection-picker-options.md
@@ -1,0 +1,1894 @@
+# Collection Picker Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Create / Skip / (Recommended) options to the terminal collection picker, lock down collection-name validation to `^[a-z0-9_-]+$`, and migrate existing names to match.
+
+**Architecture:** Backend-first — tighten the shared validator and ship the slugify migration before any UI work. Picker changes extract pure helpers (testable) and keep curses rendering logic separate. Per-name validation on `/v1/skills` lives in the handler (after `canonicalize_collection_names`) to preserve case-tolerance for clients.
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy 2, Alembic (backend); Next.js 16, React 19, TypeScript (web); Python curses (terminal picker); pytest, Playwright (tests).
+
+**Spec:** `docs/superpowers/specs/2026-04-17-collection-picker-options-design.md`
+
+---
+
+## File Structure
+
+| Path | Responsibility | Action |
+|---|---|---|
+| `backend/app/validators/collection_validator.py` | Shared name-validation rule (regex + reserved + length/newline/XML) | Modify |
+| `backend/tests/unit/test_collection_validator.py` | Unit tests for the above | Extend |
+| `backend/alembic/versions/0012_slugify_collection_names.py` | One-time rename of existing collection names + skill references | Create |
+| `backend/tests/integration/test_migration_0012_slugify.py` | Integration tests for the migration | Create |
+| `backend/app/api/skills.py` | Add post-canonicalize per-name validation on create/update | Modify |
+| `backend/tests/integration/test_skills_api.py` | Tests for the new handler-level validation | Create |
+| `src/lib/collection-validation.ts` | Frontend mirror of validator (pure function) | Create |
+| `src/components/collections/NewCollectionModal.tsx` | Wire validator into Create modal | Modify |
+| `src/components/collections/CollectionPicker.tsx` | Gate `canCreate` on slug validity | Modify |
+| `e2e/collection-validation.spec.ts` | Playwright coverage for name validation | Create |
+| `plugin/bin/skillnote-pick` | Extract pure helpers + add `(Recommended)` label + Skip row + Ctrl+K + create flow | Modify |
+| `plugin/tests/test_skillnote_pick_helpers.py` | Unit tests for extracted helpers | Create |
+| `plugin/skills/collection/SKILL.md` | Add Create / Skip options + `(Recommended)` description | Modify |
+| `plugin/skills/skill-push/SKILL.md` | Informational guidance on collection-name rule | Modify |
+
+---
+
+## Task 1: Extend collection-name validator with regex + reserved words
+
+**Files:**
+- Modify: `backend/app/validators/collection_validator.py`
+- Test: `backend/tests/unit/test_collection_validator.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `backend/tests/unit/test_collection_validator.py` and add these cases (file already exists — extend, don't replace):
+
+```python
+# Add near existing tests
+import pytest
+from app.validators.collection_validator import validate_collection_name
+
+
+def test_valid_slug_lowercase_hyphens_underscores_digits():
+    assert validate_collection_name("frontend") == []
+    assert validate_collection_name("my-app_2") == []
+    assert validate_collection_name("a") == []
+    assert validate_collection_name("a" * 128) == []
+
+
+def test_rejects_uppercase():
+    errs = validate_collection_name("Frontend")
+    assert any("lowercase" in e.lower() or "letters, numbers" in e for e in errs)
+
+
+def test_rejects_space():
+    errs = validate_collection_name("my app")
+    assert len(errs) >= 1
+
+
+def test_rejects_special_chars():
+    errs = validate_collection_name("foo!")
+    assert len(errs) >= 1
+
+
+def test_rejects_over_128_chars():
+    errs = validate_collection_name("a" * 129)
+    assert any("128" in e for e in errs)
+
+
+def test_rejects_reserved_words():
+    assert any("anthropic" in e for e in validate_collection_name("anthropic-stuff"))
+    assert any("claude" in e for e in validate_collection_name("claude-code"))
+
+
+def test_empty_is_rejected():
+    assert validate_collection_name("") != []
+    assert validate_collection_name("   ") != []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && pytest tests/unit/test_collection_validator.py -v
+```
+
+Expected: multiple failures (the new regex/reserved-word checks don't exist yet).
+
+- [ ] **Step 3: Implement the new rules**
+
+Replace the contents of `backend/app/validators/collection_validator.py` with:
+
+```python
+import re
+
+from app.validators.skill_validator import RESERVED_WORDS
+
+COLLECTION_NAME_MAX = 128
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
+
+
+def validate_collection_name(name: str) -> list[str]:
+    errors: list[str] = []
+    if name is None:
+        errors.append("Collection name is required")
+        return errors
+    stripped = name.strip()
+    if not stripped:
+        errors.append("Collection name is required")
+        return errors
+    if len(stripped) > COLLECTION_NAME_MAX:
+        errors.append(f"Collection name must be {COLLECTION_NAME_MAX} characters or fewer")
+    if "\n" in stripped or "\r" in stripped:
+        errors.append("Collection name cannot contain newlines")
+    if not NAME_PATTERN.match(stripped):
+        errors.append("Collection name must contain only lowercase letters, numbers, hyphens, and underscores")
+    for word in RESERVED_WORDS:
+        if word in stripped:
+            errors.append(f'Collection name cannot contain reserved word "{word}"')
+    if XML_TAG_RE.search(stripped):
+        errors.append("Collection name cannot contain XML tags")
+    return errors
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/unit/test_collection_validator.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/validators/collection_validator.py backend/tests/unit/test_collection_validator.py
+git commit -m "feat(backend): tighten collection-name validation to [a-z0-9_-]+ with reserved words"
+```
+
+---
+
+## Task 2: Create frontend validator mirror
+
+**Files:**
+- Create: `src/lib/collection-validation.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+// src/lib/collection-validation.ts
+// Mirror of backend/app/validators/collection_validator.py
+
+export const COLLECTION_NAME_MAX = 128
+
+const NAME_PATTERN = /^[a-z0-9_-]+$/
+const RESERVED_WORDS = ['anthropic', 'claude']
+const XML_TAG_RE = /<\/?[a-zA-Z][^>]*>/
+
+export type ValidationError = { field: string; message: string }
+
+export function validateCollectionName(name: string): ValidationError[] {
+  const errors: ValidationError[] = []
+  if (!name || !name.trim()) {
+    errors.push({ field: 'name', message: 'Name is required' })
+    return errors
+  }
+  const stripped = name.trim()
+  if (stripped.length > COLLECTION_NAME_MAX) {
+    errors.push({ field: 'name', message: `Name must be ${COLLECTION_NAME_MAX} characters or fewer` })
+  }
+  if (!NAME_PATTERN.test(stripped)) {
+    errors.push({ field: 'name', message: 'Only lowercase letters, numbers, hyphens, and underscores allowed' })
+  }
+  for (const word of RESERVED_WORDS) {
+    if (stripped.includes(word)) {
+      errors.push({ field: 'name', message: `Name cannot contain reserved word "${word}"` })
+    }
+  }
+  if (XML_TAG_RE.test(stripped)) {
+    errors.push({ field: 'name', message: 'Name cannot contain XML tags' })
+  }
+  return errors
+}
+
+/** Slugify algorithm — shared with the slugify migration + picker's folder-suggestion. */
+export function slugifyCollectionName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')   // runs of invalid → single hyphen
+    .replace(/-+/g, '-')              // collapse consecutive hyphens
+    .replace(/^-|-$/g, '')            // strip leading/trailing hyphens
+    .slice(0, COLLECTION_NAME_MAX)
+}
+
+export function isValidCollectionSlug(s: string): boolean {
+  return validateCollectionName(s).length === 0
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors related to the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/collection-validation.ts
+git commit -m "feat(frontend): add collection-name validator + slugify helper (mirrors backend)"
+```
+
+---
+
+## Task 3: Slugify migration for existing collection names
+
+**Files:**
+- Create: `backend/alembic/versions/0012_slugify_collection_names.py`
+- Test: `backend/tests/integration/test_migration_0012_slugify.py`
+
+- [ ] **Step 1a: Write the failing algorithm unit test**
+
+This codebase doesn't have an `alembic upgrade`-running test harness — integration tests hit a live API via urllib. The important logic in the migration is the pure Python slugifier + collision resolver. Cover that with a unit test of the migration module's helpers.
+
+Create `backend/tests/unit/test_migration_0012_slugify_algorithm.py`:
+
+```python
+"""Unit tests for the slugify algorithm used by migration 0012.
+
+We import the private helpers from the migration module and exercise them
+directly, so we don't need a running DB to validate the naming logic.
+"""
+import importlib.util
+import hashlib
+from pathlib import Path
+
+
+def _load():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "alembic" / "versions" / "0012_slugify_collection_names.py"
+    )
+    spec = importlib.util.spec_from_file_location("m0012", path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_slugify_basic():
+    m = _load()
+    assert m._slugify("Frontend") == "frontend"
+    assert m._slugify("lp assessment") == "lp-assessment"
+    assert m._slugify("my-app") == "my-app"
+    assert m._slugify("!!!") == ""
+
+
+def test_slugify_collapses_and_strips():
+    m = _load()
+    assert m._slugify("   --Foo!!Bar--") == "foo-bar"
+
+
+def test_fallback_uses_hash8():
+    m = _load()
+    expected = f"collection-{hashlib.sha1(b'!!!').hexdigest()[:8]}"
+    assert m._fallback("!!!") == expected
+
+
+def test_fallback_deterministic():
+    m = _load()
+    assert m._fallback("xyz") == m._fallback("xyz")
+```
+
+- [ ] **Step 1b: Write the failing migration-behavior integration test**
+
+The integration-test pattern in this repo hits a live API. Create a smoke test that relies on `docker compose up` having run the migration, and verifies the post-migration state via the API:
+
+Create `backend/tests/integration/test_migration_0012_slugify.py`:
+
+```python
+"""Post-migration smoke test for 0012.
+
+Verifies that after the backend starts (which runs `alembic upgrade head`
+per the Dockerfile), every collection name returned by /v1/collections
+matches the new regex. Skips if API unreachable.
+"""
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+
+import pytest
+
+BASE_URL = os.environ.get("SKILLNOTE_TEST_BASE_URL", "http://127.0.0.1:8082")
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+
+def _get_collections():
+    try:
+        with urllib.request.urlopen(f"{BASE_URL}/v1/collections") as r:
+            return json.loads(r.read())
+    except Exception as e:
+        pytest.skip(f"API not reachable: {e}")
+
+
+def test_all_collection_names_are_valid_slugs():
+    cols = _get_collections()
+    bad = [c["name"] for c in cols if not NAME_PATTERN.match(c["name"])]
+    assert not bad, f"Non-slug collection names still present after migration: {bad}"
+
+
+def test_collection_names_are_bounded():
+    cols = _get_collections()
+    over = [c["name"] for c in cols if len(c["name"]) > 128]
+    assert not over, f"Names over 128 chars: {over}"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && pytest tests/unit/test_migration_0012_slugify_algorithm.py -v
+```
+
+Expected: import fails (migration file doesn't exist yet). The integration test will skip without a running API — that's fine; we'll run it after Step 3.
+
+- [ ] **Step 3: Implement the migration**
+
+Create `backend/alembic/versions/0012_slugify_collection_names.py`:
+
+```python
+"""slugify collection names
+
+Revision ID: 0012_slugify_collection_names
+Revises: 0011_collections_table
+Create Date: 2026-04-18
+"""
+import hashlib
+import re
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0012_slugify_collection_names'
+down_revision = '0011_collections_table'
+branch_labels = None
+depends_on = None
+
+
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+MAX_LEN = 128
+
+
+def _slugify(name: str) -> str:
+    s = name.lower()
+    s = re.sub(r"[^a-z0-9_-]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    s = s.strip("-")
+    return s[:MAX_LEN]
+
+
+def _fallback(original: str) -> str:
+    return f"collection-{hashlib.sha1(original.encode('utf-8')).hexdigest()[:8]}"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Gather every distinct collection name (union of collections table + skills embedded arrays)
+    rows = conn.execute(sa.text(
+        """
+        SELECT name, created_at FROM (
+            SELECT name, created_at FROM collections
+            UNION
+            SELECT DISTINCT unnest(collections) AS name, now() AS created_at
+            FROM skills
+            WHERE collections IS NOT NULL AND collections != '{}'
+        ) u
+        ORDER BY created_at, name
+        """
+    )).all()
+
+    # 2. Build the rename map with collision resolution
+    rename: dict[str, str] = {}
+    used: set[str] = set()
+    for name, _created in rows:
+        if NAME_PATTERN.match(name) and len(name) <= MAX_LEN:
+            used.add(name)
+            continue
+        candidate = _slugify(name) or _fallback(name)
+        if candidate in used:
+            base = candidate
+            i = 2
+            while f"{base}-{i}" in used:
+                i += 1
+            candidate = f"{base}-{i}"
+        rename[name] = candidate
+        used.add(candidate)
+
+    if not rename:
+        return  # idempotent no-op
+
+    # 3. Rename collections table rows atomically using a VALUES-based UPDATE
+    pairs = list(rename.items())
+    values_sql = ", ".join(f"(:old_{i}, :new_{i})" for i in range(len(pairs)))
+    params = {}
+    for i, (old, new) in enumerate(pairs):
+        params[f"old_{i}"] = old
+        params[f"new_{i}"] = new
+    conn.execute(sa.text(
+        f"UPDATE collections SET name = m.new_name, updated_at = now() "
+        f"FROM (VALUES {values_sql}) AS m(old_name, new_name) "
+        f"WHERE collections.name = m.old_name"
+    ), params)
+
+    # 4. Rewrite skill.collections arrays — apply each rename pair
+    for old, new in pairs:
+        conn.execute(sa.text(
+            "UPDATE skills SET collections = array_replace(collections, :old, :new) "
+            "WHERE :old = ANY(collections)"
+        ), {"old": old, "new": new})
+
+
+def downgrade() -> None:
+    # Cannot recover original casing/punctuation without a pre-migration stash
+    pass
+```
+
+- [ ] **Step 4: Run algorithm tests to verify they pass**
+
+```bash
+cd backend && pytest tests/unit/test_migration_0012_slugify_algorithm.py -v
+```
+
+Expected: all four pass.
+
+- [ ] **Step 5: Apply the migration to a dev DB and run the post-migration smoke test**
+
+```bash
+docker compose up --build -d postgres api
+# API startup runs `alembic upgrade head` automatically
+cd backend && pytest tests/integration/test_migration_0012_slugify.py -v
+```
+
+Expected: both integration tests pass (or skip if API not reachable — run `docker compose logs api` to confirm `alembic upgrade` ran).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/alembic/versions/0012_slugify_collection_names.py \
+        backend/tests/unit/test_migration_0012_slugify_algorithm.py \
+        backend/tests/integration/test_migration_0012_slugify.py
+git commit -m "feat(backend): add migration 0012 to slugify existing collection names"
+```
+
+---
+
+## Task 4: Handler-level validation on `POST /v1/skills`
+
+**Files:**
+- Modify: `backend/app/api/skills.py` (around line 305)
+- Test: `backend/tests/integration/test_skills_api.py` (create new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Integration tests in this repo hit a live API via urllib (see `backend/tests/integration/test_collections_api.py` for the pattern). The global exception handler wraps `HTTPException.detail` as `{"error": {...}}`, so assertions check `body["error"]["code"]` (confirmed by `test_collections_api.py:77`).
+
+Create `backend/tests/integration/test_skills_api.py`:
+
+```python
+"""Integration tests for skill-create/update collection-name validation.
+
+Requires a running backend on 127.0.0.1:8082 (`docker compose up api`).
+Tests skip if API unreachable.
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+import pytest
+
+BASE_URL = os.environ.get("SKILLNOTE_TEST_BASE_URL", "http://127.0.0.1:8082")
+
+
+def _request(method: str, path: str, body: dict | None = None):
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        method=method,
+        headers={"Content-Type": "application/json"} if body else {},
+        data=(json.dumps(body).encode() if body is not None else None),
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            text = r.read().decode()
+            return r.status, json.loads(text) if text else None
+    except urllib.error.HTTPError as e:
+        text = e.read().decode()
+        return e.code, json.loads(text) if text else None
+    except Exception as e:
+        pytest.skip(f"API not reachable: {e}")
+
+
+@pytest.fixture
+def seed_collection():
+    name = "frontend"
+    _request("POST", "/v1/collections", {"name": name, "description": ""})  # ignore 409 if already exists
+    yield name
+
+
+@pytest.fixture
+def unique_skill_slug():
+    return f"test-skill-{uuid.uuid4().hex[:8]}"
+
+
+def _skill_payload(slug: str, collections: list[str]):
+    return {
+        "name": slug,
+        "slug": slug,
+        "description": "validation test skill",
+        "content_md": "",
+        "collections": collections,
+    }
+
+
+def test_create_skill_rejects_invalid_collection_name(seed_collection, unique_skill_slug):
+    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["Bad Name"]))
+    assert status == 422
+    assert body["error"]["code"] == "COLLECTION_NAME_INVALID"
+
+
+def test_create_skill_accepts_canonicalizable_variant(seed_collection, unique_skill_slug):
+    status, body = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["Frontend"]))
+    assert status == 201, body
+    assert body["collections"] == ["frontend"]
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+
+
+def test_update_skill_rejects_invalid_collection_name(seed_collection, unique_skill_slug):
+    status, _ = _request("POST", "/v1/skills", _skill_payload(unique_skill_slug, ["frontend"]))
+    assert status == 201
+    status, body = _request(
+        "PATCH", f"/v1/skills/{unique_skill_slug}", {"collections": ["Bad Name"]}
+    )
+    assert status == 422
+    assert body["error"]["code"] == "COLLECTION_NAME_INVALID"
+    _request("DELETE", f"/v1/skills/{unique_skill_slug}")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Make sure a backend is up: `docker compose up --build -d postgres api`.
+
+```bash
+cd backend && pytest tests/integration/test_skills_api.py -v
+```
+
+Expected: `test_create_skill_rejects_invalid_collection_name` fails (handler does not reject invalid names yet). `test_create_skill_accepts_canonicalizable_variant` passes (today's permissive behavior). The update test is covered in Task 5.
+
+- [ ] **Step 3: Add validation to the create_skill handler**
+
+In `backend/app/api/skills.py`, find the `create_skill` function (around line 295). Change the section that calls `canonicalize_collection_names` (around line 305) from:
+
+```python
+    # Canonicalize: map case variants to existing stored forms, de-duplicate
+    canonical_collections = canonicalize_collection_names(db, payload.collections or [])
+
+    # Check collection skill-count limits
+    for col_name in canonical_collections:
+        err = validate_collection_skill_count(db, col_name)
+        if err:
+            raise api_error(422, "COLLECTION_LIMIT_REACHED", err)
+```
+
+to:
+
+```python
+    # Canonicalize: map case variants to existing stored forms, de-duplicate
+    canonical_collections = canonicalize_collection_names(db, payload.collections or [])
+
+    # Validate each canonical name against the shared collection-name rule
+    for col_name in canonical_collections:
+        name_errs = validate_collection_name(col_name)
+        if name_errs:
+            raise api_error(422, "COLLECTION_NAME_INVALID",
+                            f'Collection "{col_name}": {"; ".join(name_errs)}')
+
+    # Check collection skill-count limits
+    for col_name in canonical_collections:
+        err = validate_collection_skill_count(db, col_name)
+        if err:
+            raise api_error(422, "COLLECTION_LIMIT_REACHED", err)
+```
+
+Add the new import at the top of `backend/app/api/skills.py` (near the existing validator imports, around line 17):
+
+```python
+from app.validators.collection_validator import validate_collection_name
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/integration/test_skills_api.py::test_create_skill_rejects_invalid_collection_name \
+                        tests/integration/test_skills_api.py::test_create_skill_accepts_canonicalizable_variant -v
+```
+
+Expected: both pass. (Third test still fails — handled in next task.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/api/skills.py backend/tests/integration/test_skills_api.py
+git commit -m "feat(backend): validate collection names in POST /v1/skills after canonicalize"
+```
+
+---
+
+## Task 5: Handler-level validation on `PATCH /v1/skills/{slug}`
+
+**Files:**
+- Modify: `backend/app/api/skills.py` (around line 369-379)
+
+- [ ] **Step 1: Re-run the previously failing test**
+
+```bash
+cd backend && pytest tests/integration/test_skills_api.py::test_update_skill_rejects_invalid_collection_name -v
+```
+
+Expected: fails.
+
+- [ ] **Step 2: Add validation to the update_skill handler**
+
+In `backend/app/api/skills.py`, find `update_skill` (around line 348). Change the collections-handling block (around line 369-379) from:
+
+```python
+    if payload.collections is not None:
+        # Canonicalize incoming names to stored case + de-duplicate variants
+        canonical_collections = canonicalize_collection_names(db, payload.collections)
+        # Check skill-count limits for any newly added collections (case-insensitive)
+        current_lower = {c.lower() for c in (skill_row.collections or [])}
+        for col_name in canonical_collections:
+            if col_name.lower() not in current_lower:
+                err = validate_collection_skill_count(db, col_name, exclude_skill_id=skill_row.id)
+                if err:
+                    raise api_error(422, "COLLECTION_LIMIT_REACHED", err)
+        skill_row.collections = canonical_collections
+```
+
+to:
+
+```python
+    if payload.collections is not None:
+        # Canonicalize incoming names to stored case + de-duplicate variants
+        canonical_collections = canonicalize_collection_names(db, payload.collections)
+        # Validate each canonical name against the shared rule
+        for col_name in canonical_collections:
+            name_errs = validate_collection_name(col_name)
+            if name_errs:
+                raise api_error(422, "COLLECTION_NAME_INVALID",
+                                f'Collection "{col_name}": {"; ".join(name_errs)}')
+        # Check skill-count limits for any newly added collections (case-insensitive)
+        current_lower = {c.lower() for c in (skill_row.collections or [])}
+        for col_name in canonical_collections:
+            if col_name.lower() not in current_lower:
+                err = validate_collection_skill_count(db, col_name, exclude_skill_id=skill_row.id)
+                if err:
+                    raise api_error(422, "COLLECTION_LIMIT_REACHED", err)
+        skill_row.collections = canonical_collections
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+```bash
+cd backend && pytest tests/integration/test_skills_api.py -v
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/api/skills.py
+git commit -m "feat(backend): validate collection names in PATCH /v1/skills/{slug} after canonicalize"
+```
+
+---
+
+## Task 6: Wire validator into `NewCollectionModal.tsx`
+
+**Files:**
+- Modify: `src/components/collections/NewCollectionModal.tsx`
+
+- [ ] **Step 1: Import the validator + wire into onChange**
+
+Open `src/components/collections/NewCollectionModal.tsx`. Add this import near the top (after the existing `createCollectionApi` import at line 6):
+
+```tsx
+import { validateCollectionName } from '@/lib/collection-validation'
+```
+
+Replace the `onChange` handler on the name input (around line 84) and the `handleCreate` function's name check (around line 25) so validation fires on input and on submit.
+
+Find this line (line 84):
+```tsx
+              onChange={e => { setName(e.target.value); if (nameError) setNameError('') }}
+```
+
+Replace with:
+```tsx
+              onChange={e => {
+                setName(e.target.value)
+                const errs = validateCollectionName(e.target.value)
+                setNameError(errs[0]?.message ?? '')
+              }}
+```
+
+Find this block (around line 24-26 inside `handleCreate`):
+```tsx
+  async function handleCreate() {
+    if (!name.trim()) { setNameError('Name is required'); nameRef.current?.focus(); return }
+    setNameError('')
+```
+
+Replace with:
+```tsx
+  async function handleCreate() {
+    const errs = validateCollectionName(name)
+    if (errs.length > 0) {
+      setNameError(errs[0].message)
+      nameRef.current?.focus()
+      return
+    }
+    setNameError('')
+```
+
+- [ ] **Step 2: Disable Create button while invalid**
+
+Find the Create button (around line 119-127). Change:
+
+```tsx
+          <Button
+            size="sm"
+            className="h-8 text-[13px] gap-1.5 bg-foreground text-background hover:bg-foreground/90"
+            disabled={!name.trim() || saving}
+            onClick={handleCreate}
+          >
+```
+
+To:
+
+```tsx
+          <Button
+            size="sm"
+            className="h-8 text-[13px] gap-1.5 bg-foreground text-background hover:bg-foreground/90"
+            disabled={!name.trim() || saving || validateCollectionName(name).length > 0}
+            onClick={handleCreate}
+          >
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 4: Smoke test manually (optional but recommended)**
+
+```bash
+docker compose up --build -d postgres api
+npm run dev
+```
+
+Visit `http://localhost:3000/collections`, click New Collection, type `Frontend` → inline error should appear, button disabled. Type `frontend` → accepts, button enabled.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/collections/NewCollectionModal.tsx
+git commit -m "feat(frontend): wire collection-name validator into NewCollectionModal"
+```
+
+---
+
+## Task 7: Gate `canCreate` in `CollectionPicker.tsx` on slug validity
+
+**Files:**
+- Modify: `src/components/collections/CollectionPicker.tsx` (around line 87-92)
+
+- [ ] **Step 1: Import the validator**
+
+Add import near the top (after line 5):
+
+```tsx
+import { isValidCollectionSlug } from '@/lib/collection-validation'
+```
+
+- [ ] **Step 2: Gate `canCreate`**
+
+Find the `canCreate` memo at line 87-92:
+
+```tsx
+  const canCreate = useMemo(() => {
+    const v = query.trim()
+    if (!v) return false
+    return !allCollections.some(c => c.toLowerCase() === v.toLowerCase()) &&
+           !selected.some(c => c.toLowerCase() === v.toLowerCase())
+  }, [query, allCollections, selected])
+```
+
+Replace with:
+
+```tsx
+  const canCreate = useMemo(() => {
+    const v = query.trim()
+    if (!v) return false
+    if (!isValidCollectionSlug(v)) return false
+    return !allCollections.some(c => c.toLowerCase() === v.toLowerCase()) &&
+           !selected.some(c => c.toLowerCase() === v.toLowerCase())
+  }, [query, allCollections, selected])
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/collections/CollectionPicker.tsx
+git commit -m "feat(frontend): gate inline Create on slug validity in CollectionPicker"
+```
+
+---
+
+## Task 8: Playwright e2e coverage for name validation
+
+**Files:**
+- Create: `e2e/collection-validation.spec.ts`
+
+- [ ] **Step 1: Write the Playwright spec**
+
+Create `e2e/collection-validation.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test'
+
+test.describe('Collection name validation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the collections list
+    await page.route('**/v1/collections', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ name: 'frontend', count: 0, description: '' }]),
+      })
+    })
+  })
+
+  test('NewCollectionModal rejects uppercase names', async ({ page }) => {
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const name = page.getByPlaceholder(/e\.g\./i)
+    await name.fill('Frontend')
+    await expect(page.getByText(/lowercase/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  test('NewCollectionModal accepts lowercase slug', async ({ page }) => {
+    await page.route('**/v1/collections', async route => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            name: 'devops', description: '',
+            created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+          }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200, contentType: 'application/json',
+          body: JSON.stringify([{ name: 'frontend', count: 0, description: '' }]),
+        })
+      }
+    })
+
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const name = page.getByPlaceholder(/e\.g\./i)
+    await name.fill('devops')
+    await expect(page.getByRole('button', { name: /^create$/i })).toBeEnabled()
+  })
+
+  test('NewCollectionModal rejects reserved word', async ({ page }) => {
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const name = page.getByPlaceholder(/e\.g\./i)
+    await name.fill('claude-stuff')
+    await expect(page.getByText(/reserved word/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+})
+```
+
+- [ ] **Step 2: Run the Playwright tests**
+
+```bash
+npx playwright test e2e/collection-validation.spec.ts
+```
+
+Expected: all three tests pass. If the test can't find the `/collections` page or the "New Collection" button, check the web UI; selectors may need adjustment based on the actual DOM.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/collection-validation.spec.ts
+git commit -m "test(e2e): playwright coverage for collection-name validation"
+```
+
+---
+
+## Task 9: Extract pure helpers in `skillnote-pick`
+
+**Files:**
+- Modify: `plugin/bin/skillnote-pick` (add helpers near top)
+- Create: `plugin/tests/test_skillnote_pick_helpers.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugin/tests/test_skillnote_pick_helpers.py`:
+
+```python
+"""Unit tests for pure helpers in skillnote-pick."""
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "bin" / "skillnote-pick"
+    spec = importlib.util.spec_from_file_location("skillnote_pick", path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_slugify_lowercases():
+    m = _load_module()
+    assert m._slugify("Frontend") == "frontend"
+
+
+def test_slugify_replaces_spaces():
+    m = _load_module()
+    assert m._slugify("My App") == "my-app"
+
+
+def test_slugify_collapses_and_strips():
+    m = _load_module()
+    assert m._slugify("  --My!!!App-- ") == "my-app"
+
+
+def test_slugify_returns_empty_for_all_invalid():
+    m = _load_module()
+    assert m._slugify("!!!") == ""
+
+
+def test_is_valid_slug():
+    m = _load_module()
+    assert m._is_valid_slug("frontend") is True
+    assert m._is_valid_slug("my-app_2") is True
+    assert m._is_valid_slug("My App") is False
+    assert m._is_valid_slug("") is False
+    assert m._is_valid_slug("claude-stuff") is False  # reserved word
+
+
+def test_resolve_recommendation_match():
+    m = _load_module()
+    existing = [("frontend", 5, []), ("backend", 3, [])]
+    assert m._resolve_recommendation("Frontend", existing) == ("pick", 0)
+
+
+def test_resolve_recommendation_create():
+    m = _load_module()
+    existing = [("frontend", 5, [])]
+    assert m._resolve_recommendation("My App", existing) == ("create", "my-app")
+
+
+def test_resolve_recommendation_none():
+    m = _load_module()
+    existing = [("frontend", 5, [])]
+    assert m._resolve_recommendation("!!!", existing) == ("none", None)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd plugin && python -m pytest tests/test_skillnote_pick_helpers.py -v
+```
+
+Expected: all helpers missing → fails.
+
+- [ ] **Step 3: Add the helpers**
+
+Open `plugin/bin/skillnote-pick`. Near the top (right after `CONFIG_PATH` at line 25), add:
+
+```python
+import re as _re
+
+RESERVED_WORDS = ("anthropic", "claude")
+_SLUG_PATTERN = _re.compile(r"^[a-z0-9_-]+$")
+_MAX_NAME = 128
+
+
+def _slugify(name):
+    s = (name or "").lower()
+    s = _re.sub(r"[^a-z0-9_-]+", "-", s)
+    s = _re.sub(r"-+", "-", s)
+    s = s.strip("-")
+    return s[:_MAX_NAME]
+
+
+def _is_valid_slug(s):
+    if not s or len(s) > _MAX_NAME:
+        return False
+    if not _SLUG_PATTERN.match(s):
+        return False
+    if any(w in s for w in RESERVED_WORDS):
+        return False
+    return True
+
+
+def _resolve_recommendation(folder_raw, existing):
+    """Returns ('pick', idx) | ('create', slug) | ('none', None)."""
+    slug = _slugify(folder_raw)
+    if not slug:
+        return ("none", None)
+    for i, (name, _count, _skills) in enumerate(existing):
+        if name == slug:
+            return ("pick", i)
+    if not _is_valid_slug(slug):
+        return ("none", None)
+    return ("create", slug)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd plugin && python -m pytest tests/test_skillnote_pick_helpers.py -v
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/bin/skillnote-pick plugin/tests/test_skillnote_pick_helpers.py
+git commit -m "feat(plugin): add pure helpers _slugify/_is_valid_slug/_resolve_recommendation"
+```
+
+---
+
+## Task 10: Replace `★` with `(Recommended)` label in curses picker
+
+**Files:**
+- Modify: `plugin/bin/skillnote-pick` (around lines 382-384, 403-404)
+
+- [ ] **Step 1: Update the list row rendering**
+
+Open `plugin/bin/skillnote-pick`. Find the list-row rendering block (around lines 378-386):
+
+```python
+                if is_focused:
+                    s(row, nx, name, ACCENT)
+                else:
+                    s(row, nx, name, DIM if not is_rec else 0)
+                if is_rec:
+                    s(row, nx + len(name) + 1, "★", YELLOW | (0 if is_focused else DIM))
+
+                cnt = str(count)
+                s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
+```
+
+Replace the `★` rendering with the `(Recommended)` bracketed label:
+
+```python
+                if is_focused:
+                    s(row, nx, name, ACCENT)
+                else:
+                    s(row, nx, name, DIM if not is_rec else 0)
+                if is_rec:
+                    rec_label = " (Recommended)"
+                    s(row, nx + len(name), rec_label, DIM if not is_focused else ACCENT)
+
+                cnt = str(count)
+                s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
+```
+
+- [ ] **Step 2: Update the right-panel preview header**
+
+Find (around lines 401-408):
+
+```python
+                # Header
+                header = sel_name
+                if sel_is_rec:
+                    header += " ★"
+                if focus == "right":
+                    s(rr, bx + left_w + 3, "❯ " + header, ACCENT)
+                else:
+                    s(rr, bx + left_w + 4, header, BOLD)
+```
+
+Replace with:
+
+```python
+                # Header
+                header = sel_name
+                if sel_is_rec:
+                    header += " (Recommended)"
+                if focus == "right":
+                    s(rr, bx + left_w + 3, "❯ " + header, ACCENT)
+                else:
+                    s(rr, bx + left_w + 4, header, BOLD)
+```
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+cd /Users/atharvapatil/friend/repo/skillnote && SKILLNOTE_HOST=localhost plugin/bin/skillnote-pick
+```
+
+Expected: the recommended collection shows `(Recommended)` next to its name, not `★`. Press esc to exit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/bin/skillnote-pick
+git commit -m "feat(plugin): replace star marker with (Recommended) bracketed label"
+```
+
+---
+
+## Task 11: Pinned Skip row + Ctrl+K hotkey + confirmation modal
+
+**Files:**
+- Modify: `plugin/bin/skillnote-pick` (list rendering + key handler)
+
+- [ ] **Step 1: Reserve a pinned row below the scrollable list**
+
+Open `plugin/bin/skillnote-pick`. Find the bottom of the list-rendering block (the `while row < h - footer_h - 1` padding loop around line 390-392):
+
+```python
+            # Pad remaining left rows
+            while row < h - footer_h - 1:
+                hline(row)
+                row += 1
+```
+
+Replace with (reserve one extra row for Skip):
+
+```python
+            # Pad remaining left rows (reserve one row for the pinned Skip entry)
+            while row < h - footer_h - 2:
+                hline(row)
+                row += 1
+
+            # Pinned Skip row — always visible
+            skip_is_focused = (focus == "left" and cur == len(filtered))  # one past last
+            hline(row)
+            skip_label = "⊘ Skip (Ctrl+K)"
+            if skip_is_focused:
+                s(row, bx + 3, "❯", ACCENT)
+                s(row, bx + 5, skip_label, ACCENT)
+            else:
+                s(row, bx + 5, skip_label, DIM)
+            row += 1
+```
+
+This extends the navigable list by one virtual row (`len(filtered)` → Skip).
+
+- [ ] **Step 2: Make Down arrow reachable into the Skip row**
+
+Find the Down-arrow handler (around line 485-492):
+
+```python
+        elif key == curses.KEY_DOWN:
+            if focus == "left":
+                if filtered and cur < len(filtered) - 1:
+                    cur += 1
+                    right_scroll = 0
+            else:
+                if sel_skills and right_scroll < len(sel_skills) - 1:
+                    right_scroll += 1
+```
+
+Replace with:
+
+```python
+        elif key == curses.KEY_DOWN:
+            if focus == "left":
+                # Allow navigating onto the pinned Skip row (index == len(filtered))
+                if cur < len(filtered):
+                    cur += 1
+                    right_scroll = 0
+            else:
+                if sel_skills and right_scroll < len(sel_skills) - 1:
+                    right_scroll += 1
+```
+
+Add a helper function near the top of the file (after `_resolve_recommendation`, before `pick(...)`):
+
+```python
+def _confirm_skip(stdscr):
+    """Draw a centered modal and return True if user confirms."""
+    h, w = stdscr.getmaxyx()
+    box_h, box_w = 5, 40
+    y = (h - box_h) // 2
+    x = (w - box_w) // 2
+    stdscr.attron(curses.A_BOLD)
+    for i in range(box_h):
+        stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
+    stdscr.attroff(curses.A_BOLD)
+    stdscr.addstr(y + 1, x + 2, "Are you sure you want to skip?", curses.A_REVERSE | curses.A_BOLD)
+    stdscr.addstr(y + 3, x + 2, "[Y] Yes       [N] Cancel", curses.A_REVERSE)
+    stdscr.refresh()
+    while True:
+        k = stdscr.getch()
+        if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
+            return True
+        if k in (ord("n"), ord("N"), 27):
+            return False
+```
+
+- [ ] **Step 3: Handle Enter on Skip row + Ctrl+K hotkey**
+
+Find the Enter-handling block (around lines 497-500):
+
+```python
+        elif key in (ord("\n"), curses.KEY_ENTER, 10, 13):
+            if filtered:
+                _, orig_idx, _ = filtered[cur]
+                return [items[orig_idx][0]]
+```
+
+Replace with:
+
+```python
+        elif key in (ord("\n"), curses.KEY_ENTER, 10, 13):
+            if focus == "left" and cur == len(filtered):
+                # Skip row
+                if _confirm_skip(stdscr):
+                    return "__SKIP__"
+                continue
+            if filtered:
+                _, orig_idx, _ = filtered[cur]
+                return [items[orig_idx][0]]
+        elif key == 11:  # Ctrl+K
+            if _confirm_skip(stdscr):
+                return "__SKIP__"
+```
+
+- [ ] **Step 4: Handle the Skip sentinel in `main()`**
+
+Find `main()` near the bottom (around line 619-628) and update the "not chosen / chosen" block. Replace:
+
+```python
+    if HAS_CURSES:
+        chosen = curses.wrapper(pick, collections, recommended)
+    else:
+        chosen = pick_fallback(collections, recommended)
+    if not chosen:
+        current = _get_current_collections()
+        if current:
+            print(f"  ✦ SkillNote: {', '.join(current)} (active)")
+        return
+    current = _get_current_collections()
+    changed = current != chosen
+    try:
+        with open(CONFIG_PATH, "w") as f:
+            json.dump({"collections": chosen}, f, indent=2)
+            f.write("\n")
+    except PermissionError:
+        print("  ✦ SkillNote: cannot write .skillnote.json (permission denied)", file=sys.stderr)
+        return
+    if changed and current is not None:
+        _clean_skills_dir()
+    _run_sync()
+```
+
+With:
+
+```python
+    if HAS_CURSES:
+        chosen = curses.wrapper(pick, collections, recommended)
+    else:
+        chosen = pick_fallback(collections, recommended)
+    if chosen is None:
+        current = _get_current_collections()
+        if current:
+            print(f"  ✦ SkillNote: {', '.join(current)} (active)")
+        return
+    current = _get_current_collections()
+    if chosen == "__SKIP__":
+        try:
+            with open(CONFIG_PATH, "w") as f:
+                json.dump({"collections": []}, f, indent=2)
+                f.write("\n")
+        except PermissionError:
+            print("  ✦ SkillNote: cannot write .skillnote.json (permission denied)", file=sys.stderr)
+            return
+        _clean_skills_dir()
+        print("  ✦ SkillNote: no collection active (skipped)")
+        return
+    changed = current != chosen
+    try:
+        with open(CONFIG_PATH, "w") as f:
+            json.dump({"collections": chosen}, f, indent=2)
+            f.write("\n")
+    except PermissionError:
+        print("  ✦ SkillNote: cannot write .skillnote.json (permission denied)", file=sys.stderr)
+        return
+    if changed and current is not None:
+        _clean_skills_dir()
+    _run_sync()
+```
+
+- [ ] **Step 5: Smoke test**
+
+```bash
+plugin/bin/skillnote-pick
+```
+
+Expected: press Down past the last collection → lands on `⊘ Skip (Ctrl+K)`. Press Enter → confirmation modal appears. Press Y → skips. Also test Ctrl+K from anywhere → modal appears. Verify `.skillnote.json` contains `{"collections": []}`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin/bin/skillnote-pick
+git commit -m "feat(plugin): add pinned Skip row + Ctrl+K hotkey + confirmation modal"
+```
+
+---
+
+## Task 12: Search-driven Create row + create flow + 409 handling
+
+**Files:**
+- Modify: `plugin/bin/skillnote-pick` (list rendering + `fetch_collections` refresh + Enter handler)
+
+- [ ] **Step 1: Add an API helper for creating collections**
+
+Near the top of `plugin/bin/skillnote-pick` (after `_get_host` at line 54), add:
+
+```python
+def _create_collection(name):
+    """Returns ('ok', None) | ('exists', count) | ('error', msg)."""
+    import urllib.error
+    host = _get_host()
+    api = f"http://{host}:8082"
+    payload = json.dumps({"name": name, "description": ""}).encode()
+    req = urllib.request.Request(
+        f"{api}/v1/collections",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=3).read()
+        return ("ok", None)
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            # Collection already exists — fetch its count
+            try:
+                data = json.loads(urllib.request.urlopen(
+                    f"{api}/v1/skills?collections={name}", timeout=3).read())
+                return ("exists", len(data))
+            except Exception:
+                return ("exists", 0)
+        return ("error", f"HTTP {e.code}")
+    except Exception as e:
+        return ("error", str(e))
+
+
+def _confirm_activate_existing(stdscr, name, count):
+    """Inline Y/N prompt when Create hits a 409. Returns True to activate."""
+    h, w = stdscr.getmaxyx()
+    box_h, box_w = 5, min(w - 4, 60)
+    y = (h - box_h) // 2
+    x = (w - box_w) // 2
+    for i in range(box_h):
+        stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
+    msg = f'"{name}" already exists with {count} skill(s).'
+    stdscr.addstr(y + 1, x + 2, msg[:box_w - 4], curses.A_REVERSE | curses.A_BOLD)
+    stdscr.addstr(y + 3, x + 2, "Activate it? [Y] Yes  [N] No", curses.A_REVERSE)
+    stdscr.refresh()
+    while True:
+        k = stdscr.getch()
+        if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
+            return True
+        if k in (ord("n"), ord("N"), 27):
+            return False
+```
+
+- [ ] **Step 2: Compute the create-suggestion row as the first list item**
+
+Find the filter block (around lines 227-231):
+
+```python
+        # Filter
+        if search:
+            filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)
+                        if search.lower() in it[0].lower()]
+        else:
+            filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)]
+```
+
+Replace with (compute create-slug and prepend/append a synthetic row):
+
+```python
+        # Filter
+        if search:
+            filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)
+                        if search.lower() in it[0].lower()]
+        else:
+            filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)]
+
+        # Determine the create-slug for this frame:
+        #   - with a search query and no existing match → "+ Create '{slugify(query)}'" (if valid)
+        #   - no query, and recommendation is "create" (folder had no match) → "+ Create '{folder_slug}'"
+        create_slug = None
+        if search:
+            qs = _slugify(search)
+            if qs and _is_valid_slug(qs) and not any(n == qs for n, _, _ in items):
+                if not filtered:  # only show create when filter is empty
+                    create_slug = qs
+        else:
+            # Use the startup recommendation if it's a "create" type
+            if recommended_kind == "create":
+                create_slug = recommended_slug
+
+        # If we're showing a create row, prepend a synthetic entry to filtered
+        if create_slug is not None:
+            synthetic = (-1, -1, (f"+ Create '{create_slug}'", 0, []))
+            filtered = [synthetic] + filtered
+```
+
+- [ ] **Step 3: Thread the recommendation result from `main()` into `pick(...)`**
+
+Find the `pick(stdscr, items, recommended=0)` signature (around line 173) and update:
+
+```python
+def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug=None):
+```
+
+Find where `pick` uses `recommended` to build `sorted_items` (around line 174-181):
+
+```python
+    # Sort: recommended first
+    sorted_items = []
+    if 0 <= recommended < len(items):
+        sorted_items.append((recommended, items[recommended]))
+    for i, it in enumerate(items):
+        if i != recommended:
+            sorted_items.append((i, it))
+```
+
+Replace with:
+
+```python
+    # Sort: recommended first (only when recommendation kind is 'pick')
+    sorted_items = []
+    if recommended_kind == "pick" and 0 <= recommended < len(items):
+        sorted_items.append((recommended, items[recommended]))
+        for i, it in enumerate(items):
+            if i != recommended:
+                sorted_items.append((i, it))
+    else:
+        for i, it in enumerate(items):
+            sorted_items.append((i, it))
+```
+
+Change the caller in `main()`. Find (around line 619):
+
+```python
+    recommended = _get_recommended(collections)
+    if HAS_CURSES:
+        chosen = curses.wrapper(pick, collections, recommended)
+    else:
+        chosen = pick_fallback(collections, recommended)
+```
+
+Replace with:
+
+```python
+    folder_raw = os.path.basename(os.getcwd())
+    rec_kind, rec_payload = _resolve_recommendation(folder_raw, collections)
+    if rec_kind == "pick":
+        recommended_idx = rec_payload
+        recommended_slug = None
+    else:
+        recommended_idx = -1
+        recommended_slug = rec_payload if rec_kind == "create" else None
+    if HAS_CURSES:
+        chosen = curses.wrapper(pick, collections, recommended_idx, rec_kind, recommended_slug)
+    else:
+        chosen = pick_fallback(collections, recommended_idx, rec_kind, recommended_slug)
+```
+
+(Remove or keep `_get_recommended` — it's no longer used from main but leaving it doesn't hurt.)
+
+- [ ] **Step 4: Handle Enter on a synthetic create row**
+
+Find the Enter-handler updated in Task 11:
+
+```python
+        elif key in (ord("\n"), curses.KEY_ENTER, 10, 13):
+            if focus == "left" and cur == len(filtered):
+                # Skip row
+                if _confirm_skip(stdscr):
+                    return "__SKIP__"
+                continue
+            if filtered:
+                _, orig_idx, _ = filtered[cur]
+                return [items[orig_idx][0]]
+```
+
+Replace with:
+
+```python
+        elif key in (ord("\n"), curses.KEY_ENTER, 10, 13):
+            if focus == "left" and cur == len(filtered):
+                # Skip row
+                if _confirm_skip(stdscr):
+                    return "__SKIP__"
+                continue
+            if filtered:
+                _, orig_idx, (sel_name, _, _) = filtered[cur]
+                if orig_idx == -1:
+                    # Synthetic "+ Create 'X'" row — create via API
+                    new_name = sel_name.split("'")[1]  # extract slug between quotes
+                    status, payload = _create_collection(new_name)
+                    if status == "ok":
+                        return [new_name]
+                    if status == "exists":
+                        if _confirm_activate_existing(stdscr, new_name, payload or 0):
+                            return [new_name]
+                        continue  # return to picker, keep query
+                    # error case — show one-line toast then continue
+                    h, w = stdscr.getmaxyx()
+                    stdscr.addstr(h - 2, 2, f"Create failed: {payload}. Press any key."[:w - 4], curses.A_REVERSE)
+                    stdscr.refresh()
+                    stdscr.getch()
+                    continue
+                return [items[orig_idx][0]]
+```
+
+- [ ] **Step 5: Smoke test**
+
+```bash
+plugin/bin/skillnote-pick
+```
+
+Expected: type a new name like `my-new-collection` → `+ Create 'my-new-collection'` appears; press Enter → collection is created via API, picker exits, `.skillnote.json` holds the new name.
+
+Type an existing name variation, e.g. `FRONTEND` if `frontend` exists — search filter still shows `frontend`; but if you type `frontend-plus` and no match exists, Create row appears.
+
+Launch from a folder like `my-random-project` that doesn't match any collection → top row is `+ Create 'my-random-project' (Recommended)`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin/bin/skillnote-pick
+git commit -m "feat(plugin): search-driven Create row + create flow + 409 activate-existing prompt"
+```
+
+---
+
+## Task 13: Update `pick_fallback()` for parity
+
+**Files:**
+- Modify: `plugin/bin/skillnote-pick` (`pick_fallback` function, around lines 515-537)
+
+- [ ] **Step 1: Replace the fallback function**
+
+Find `pick_fallback(items, recommended=0)` (around line 515). Replace the entire function with:
+
+```python
+def pick_fallback(items, recommended=0, recommended_kind="pick", recommended_slug=None):
+    """Non-curses fallback — plain numbered input, parity with curses options."""
+    print("\n ✦ S K I L L N O T E — Pick a collection\n")
+
+    # Optional Create-suggestion row for unmatched folder
+    offset = 0
+    if recommended_kind == "create" and recommended_slug:
+        print(f"  0. + Create '{recommended_slug}' (Recommended)")
+        offset = 1
+
+    if recommended_kind == "pick" and 0 <= recommended < len(items):
+        order = [recommended] + [i for i in range(len(items)) if i != recommended]
+    else:
+        order = list(range(len(items)))
+
+    for pos, i in enumerate(order):
+        name, count, skills = items[i]
+        rec = " (Recommended)" if i == recommended and recommended_kind == "pick" else ""
+        print(f"  {pos + 1}. {name} ({count} skills){rec}")
+
+    print(f"  C. Create new collection")
+    print(f"  S. Skip (use no collections)")
+    print()
+    try:
+        reply = input("  > ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    if not reply or reply.lower() == "q":
+        return None
+
+    if reply.lower() == "s":
+        try:
+            confirm = input("  Are you sure you want to skip? [Y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        return "__SKIP__" if confirm in ("y", "yes") else None
+
+    if reply.lower() == "c":
+        try:
+            new_name = input("  New collection name: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        if not _is_valid_slug(new_name):
+            print("  Invalid name. Use only lowercase letters, numbers, hyphens, underscores.")
+            return None
+        status, payload = _create_collection(new_name)
+        if status == "ok":
+            return [new_name]
+        if status == "exists":
+            try:
+                confirm = input(f'  "{new_name}" exists with {payload or 0} skill(s). Activate? [Y/N] ').strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                return None
+            return [new_name] if confirm in ("y", "yes") else None
+        print(f"  Create failed: {payload}")
+        return None
+
+    # "0" → create-suggestion
+    if offset and reply == "0":
+        status, payload = _create_collection(recommended_slug)
+        if status == "ok":
+            return [recommended_slug]
+        if status == "exists":
+            return [recommended_slug]  # existing — just activate it
+        print(f"  Create failed: {payload}")
+        return None
+
+    try:
+        n = int(reply)
+        if 1 <= n <= len(items):
+            return [items[order[n - 1]][0]]
+    except (ValueError, IndexError):
+        pass
+    return None
+```
+
+- [ ] **Step 2: Smoke test the fallback**
+
+```bash
+plugin/bin/skillnote-pick < /dev/null
+```
+
+The non-tty branch runs `pick_fallback`. Use the picker from a TTY-less environment (e.g., pipe a number). Expected: all three options (numeric, `C`, `S`) work correctly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugin/bin/skillnote-pick
+git commit -m "feat(plugin): bring pick_fallback to parity with curses (Create/Skip/Recommended)"
+```
+
+---
+
+## Task 14: Update the slash-command picker SKILL.md
+
+**Files:**
+- Modify: `plugin/skills/collection/SKILL.md`
+
+- [ ] **Step 1: Replace the Step 2 example and add Create + Skip + Recommended**
+
+Open `plugin/skills/collection/SKILL.md`. Replace the entire Step 2 block (lines 19-42) with:
+
+```markdown
+## Step 2: Show picker — MUST use AskUserQuestion
+
+You MUST call the AskUserQuestion tool. Do NOT print a table or ask a text question.
+
+Call AskUserQuestion with these EXACT parameters:
+- `header`: "SkillNote"
+- `question`: "Pick a collection for this project:"
+- Build `options` in this order:
+  1. **Recommended first:** if `basename(cwd)` (lowercase, non-alphanumeric replaced with `-`) matches an existing collection name, put that option first and append ` · Recommended` to its description. Example description: `"12 skills · Recommended"`.
+  2. All other existing collections, each with `label` = name, `description` = `"{count} skills"`.
+  3. **If `.skillnote.json` exists**, add "(current)" to the currently-active collection's label.
+  4. `{"label": "Create new collection…", "description": "type a name next"}`
+  5. `{"label": "Skip (use no collections)", "description": "no skills synced"}`
+
+Example AskUserQuestion call:
+```json
+{
+  "header": "SkillNote",
+  "question": "Pick a collection for this project:",
+  "options": [
+    {"label": "frontend (current)", "description": "12 skills · Recommended"},
+    {"label": "backend", "description": "8 skills"},
+    {"label": "devops", "description": "3 skills"},
+    {"label": "Create new collection…", "description": "type a name next"},
+    {"label": "Skip (use no collections)", "description": "no skills synced"}
+  ]
+}
+```
+```
+
+- [ ] **Step 2: Replace Step 3 (Apply selection) with branching logic**
+
+Replace Step 3 (lines 44-55) with:
+
+```markdown
+## Step 3: Apply selection
+
+Branch based on what the user picked:
+
+### 3a. Existing collection or "(current)" option
+Strip any ` (current)` suffix. Then run:
+
+```bash
+echo '{"collections": ["<SELECTED_NAME>"]}' > .skillnote.json
+skillnote-sync --force 2>/dev/null || true
+```
+
+Tell the user: "Switched to {name}. Skills will refresh."
+
+### 3b. "Create new collection…"
+Ask the user for a name in a plain text turn:
+
+> What should the new collection be called? (lowercase letters, numbers, hyphens, underscores — example: `my-project`)
+
+Wait for their reply. Validate: name must match `^[a-z0-9_-]+$`, be 1–128 chars, and not contain `anthropic` or `claude`. If invalid, explain and re-prompt once.
+
+Create the collection:
+
+```bash
+curl -sf -X POST "http://${CLAUDE_PLUGIN_OPTION_HOST:-localhost}:8082/v1/collections" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "<NAME>", "description": ""}'
+```
+
+If curl returns a 409 conflict, the collection already exists — tell the user and offer to activate it instead (one-question AskUserQuestion: `Yes, activate / No, pick a different name`).
+
+On success, write the name to `.skillnote.json` and run sync the same way as 3a.
+
+### 3c. "Skip (use no collections)"
+Write an empty collections list:
+
+```bash
+echo '{"collections": []}' > .skillnote.json
+skillnote-sync --force 2>/dev/null || true
+```
+
+Tell the user: "Skipped. No skills will be synced to this project."
+```
+
+- [ ] **Step 3: Smoke test via `/skillnote:collection`**
+
+Run `/skillnote:collection` in a Claude Code session and verify the three branches work as expected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugin/skills/collection/SKILL.md
+git commit -m "feat(plugin): add Create/Skip/Recommended options to /skillnote:collection"
+```
+
+---
+
+## Task 15: Add collection-name guidance to skill-push SKILL.md
+
+**Files:**
+- Modify: `plugin/skills/skill-push/SKILL.md` (Step 4, around line 66-70)
+
+- [ ] **Step 1: Update Step 4 guidance**
+
+Open `plugin/skills/skill-push/SKILL.md`. Find the Step 4 block (around line 66-70):
+
+```markdown
+Every skill must belong to at least one collection. Use **AskUserQuestion** to let the user pick:
+- Show existing collections from the list above as options
+- Include an option to type a new collection name
+- Recommend the collection that best fits the skill's domain
+- A skill cannot be pushed without a collection
+```
+
+Replace with:
+
+```markdown
+Every skill must belong to at least one collection. Use **AskUserQuestion** to let the user pick:
+- Show existing collections from the list above as options
+- Include an option to type a new collection name — names must match `^[a-z0-9_-]+$` (lowercase letters, numbers, hyphens, underscores), 1–128 chars, and cannot contain reserved words `anthropic` or `claude`
+- Recommend the collection that best fits the skill's domain
+- A skill cannot be pushed without a collection
+
+If the user types an invalid name, the POST /v1/skills call will return 422 `COLLECTION_NAME_INVALID`. Surface the error, explain the rule, and ask them to type a valid name before retrying.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add plugin/skills/skill-push/SKILL.md
+git commit -m "docs(plugin): document collection-name rule in skill-push guidance"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Run the full backend test suite**
+
+```bash
+cd backend && pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run Playwright e2e**
+
+```bash
+npx playwright test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run plugin helper tests**
+
+```bash
+cd plugin && python -m pytest tests/
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Push the branch and open a PR**
+
+```bash
+git push -u origin feat/collection-picker-options
+gh pr create --title "feat: collection picker options (Create / Skip / Recommended)" --body "$(cat <<'EOF'
+## Summary
+- Adds Create new / Skip / (Recommended) options to the terminal collection picker (`plugin/bin/skillnote-pick`) and the `/skillnote:collection` slash command
+- Locks down collection-name validation to `^[a-z0-9_-]+$` everywhere
+- Adds migration 0012 to slugify existing collection names (with skill-reference updates)
+
+## Test plan
+- [ ] Backend pytest passes
+- [ ] Playwright e2e passes
+- [ ] Plugin helper tests pass
+- [ ] Manual picker walkthrough: Recommended for known folder, Create for new folder, Skip clears
+- [ ] Confirm migration runs cleanly on a seed DB and is idempotent
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage check:** Tasks 1-2 cover validator infrastructure; Task 3 covers the slugify migration; Tasks 4-5 cover handler-level skill API validation; Tasks 6-8 cover web UI; Tasks 9-13 cover the curses picker; Task 14 covers the slash command; Task 15 covers skill-push guidance. Every "Touch Points" bullet in the spec maps to a task.
+
+**Placeholders:** none. All code blocks contain literal implementations.
+
+**Type consistency:** `_slugify`, `_is_valid_slug`, `_resolve_recommendation` have the same signatures in Task 9 (helpers) and Task 12 (callers).

--- a/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
+++ b/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
@@ -53,10 +53,10 @@ This spec adds all three, and tightens collection-name validation to keep the re
 ### Validation
 
 - **`backend/app/validators/collection_validator.py`** — add regex rule `^[a-z0-9_-]+$` and reserved-word check (`anthropic`, `claude`, matching `src/lib/skill-validation.ts:7`) alongside existing length/newline/XML checks. This validator is already wired into `POST /v1/collections` via `backend/app/schemas/collection.py:19-25`, so no schema change needed there.
-- **`backend/app/schemas/skill.py`** — add a `field_validator` on `SkillCreate.collections` / `SkillUpdate.collections` that runs each entry through `validate_collection_name`. Closes the skill-push path that currently lets arbitrary strings land in `skills.collections[]`.
+- **`backend/app/schemas/skill.py`** — extend the existing `SkillCreate.check_collections` field_validator (lines 64-70) so that, after the current "at least one collection required" check, it also runs each entry through `validate_collection_name`. Apply the same change to `SkillUpdate.collections`. Closes the skill-push path that currently lets arbitrary strings land in `skills.collections[]`.
 - **`src/lib/collection-validation.ts`** (new) — mirror backend rule for frontend use; export `validateCollectionName`, `normalizeCollectionName`, `slugFromCollectionName` following the pattern in `src/lib/skill-validation.ts`.
 - **`src/components/collections/NewCollectionModal.tsx`** — wire validator; show inline error and disable Create button when invalid.
-- **`src/components/collections/CollectionPicker.tsx`** — gate `canCreate` on slug validity; disable `+ Create 'X'` row when query fails validation. Also apply validation to the offline-fallback write at lines 37-42 so local state cannot drift from backend rules.
+- **`src/components/collections/CollectionPicker.tsx`** — gate `canCreate` on slug validity; disable `+ Create 'X'` row when query fails validation. The existing `persistCollection` offline-fallback helper (lines 35-43) is only reached via `add('__create__')` after `canCreate === true`, so the `canCreate` gate is the single enforcement point — no separate validation needed inside `persistCollection`.
 - **`plugin/skills/skill-push/SKILL.md`** — update Step 4 to instruct the user that new collection names must match `^[a-z0-9_-]+$`. Informational guidance only; the backend `SkillCreate` validator is the actual enforcement point.
 
 ### Migration
@@ -79,9 +79,10 @@ Frontend unit tests for the pure validator are intentionally omitted — `packag
 1. `skillnote-pick` runs pre-`claude`, fetches `GET /v1/collections`.
 2. Computes `folder_raw = basename(cwd)` and `folder_slug = slugify(folder_raw)` (same algorithm as the migration).
 3. Classifies into one of three recommendation states:
-   - **Match:** `folder_raw.lower()` equals an existing collection name (case-insensitive) → that row gets `(Recommended)` label and sorts to top.
-   - **Create-suggestion:** no match, but `folder_slug` is non-empty → top row becomes `+ Create '{folder_slug}' (Recommended)`. Display uses the slugified form so the suggested name is always valid.
-   - **None:** no match and `folder_slug` is empty → no recommendation; list shows existing collections only.
+   - **Match:** `folder_slug` equals an existing collection name (after migration, existing names are all lowercase slugs, so this is a direct equality check) → that row gets `(Recommended)` label and sorts to top.
+   - **Create-suggestion:** no match, but `folder_slug` is non-empty → top row becomes `+ Create '{folder_slug}' (Recommended)`. Display uses the slugified form so the suggested name is always valid. Example: folder `My App` → `folder_slug = my-app`; if `my-app` exists → Match; if not → Create-suggestion.
+   - **None:** `folder_slug` is empty (e.g., folder was all symbols like `~~~`) → no recommendation; list shows existing collections only.
+4. **During search typing:** the startup recommendation row is replaced by standard search-filter behavior. If the typed query doesn't match any existing name and `slugify(query)` is non-empty, a dynamic `+ Create '{slugify(query)}'` row appears at the bottom of the (empty) filtered list. Clearing the search box restores the startup recommendation view.
 
 ### Interactions
 
@@ -143,7 +144,7 @@ Single shared rule across backend, frontend, and picker:
 
 | Site | Behavior |
 |---|---|
-| `backend/app/validators/collection_validator.py` | Return error list; POST `/v1/collections` returns 400 with message when rule fails. |
+| `backend/app/validators/collection_validator.py` | Return error list; the Pydantic `check_name` field_validator in `schemas/collection.py:19-25` raises `ValueError`, which FastAPI surfaces as **422 Unprocessable Entity** (same pattern `skill-push/SKILL.md:106` documents). |
 | `src/lib/collection-validation.ts` (new) | Pure function, mirror of backend. |
 | `NewCollectionModal.tsx` | Inline error below input (`AlertCircle` + red text matching the existing `nameError` pattern at `NewCollectionModal.tsx:91-96`); Create button disabled while invalid. |
 | `CollectionPicker.tsx` (inline web picker) | `canCreate` memo gated on slug validity; `+ Create 'X'` option hidden when invalid. |
@@ -200,7 +201,7 @@ Example: `[Frontend, "frontend-", frontend_]` (created in that order) → `[fron
 | `.skillnote.json` write fails (EACCES) | Preserve current `PermissionError` branch in both Skip and normal-pick paths. |
 | Sync script failure | Preserve current silent exit. Next `claude` launch retries. |
 | Migration interrupted mid-run | Single transaction ensures rollback; no partial rename state. |
-| Migration produces empty slug | Fallback `collection-{id}`, WARN-level log entry during migration for operator audit. |
+| Migration produces empty slug | Fallback `collection-{hash8}` (first 8 hex chars of `sha1(original_name)`), WARN-level log entry during migration for operator audit. |
 | Skip when already on empty collection | Confirm modal still shown; confirm is a no-op exit. No special branch. |
 | Concurrent pickers on same project | Last-writer-wins on `.skillnote.json`. No locking. |
 
@@ -251,8 +252,9 @@ None. All UX and implementation questions resolved during brainstorming.
 
 ## Success Criteria
 
-- User can start `claude` in a new project directory, see a `+ Create '{folder}' (Recommended)` row at the top of the picker, press Enter, and have a matching collection created and activated without leaving the terminal.
+- User can start `claude` in a new project directory, see a `+ Create '{folder_slug}' (Recommended)` row at the top of the picker, press Enter, and have a matching collection created and activated without leaving the terminal.
 - User can press `Ctrl+K` (or navigate to the pinned Skip row), confirm the modal, and have `.skillnote.json` written with `{"collections": []}` and all local skills cleaned.
-- `POST /v1/collections` with name `Frontend` returns a 400 with a clear validation message; `frontend` succeeds.
+- `POST /v1/collections` with name `Frontend` returns a 422 with a clear validation message; `frontend` succeeds.
+- `POST /v1/skills` with `collections: ["Bad Name"]` returns 422; `collections: ["frontend"]` succeeds.
 - After migration, every collection name in the database matches `^[a-z0-9_-]+$`, and all skill records reference the post-migration names.
 - Running the migration twice is a no-op on the second run.

--- a/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
+++ b/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
@@ -1,0 +1,252 @@
+# Collection Picker — Create / Skip / Recommendation Options
+
+**Date:** 2026-04-17
+**Branch:** `feat/collection-picker-options`
+**Author:** Atharva (via brainstorming session)
+**Status:** Design approved; pending implementation plan
+
+---
+
+## Problem
+
+The current collection picker (`plugin/bin/skillnote-pick`) lets a user pick one of the existing collections as the active skill set for a project. It lacks three options that users need at project startup:
+
+1. **Create new** — if none of the existing collections fit, the user has no way to create one inline.
+2. **Skip** — no explicit way to opt out; pressing `esc` preserves the current selection instead of clearing it, so "run Claude with no SkillNote skills" is not reachable from the picker.
+3. **Recommendation for unknown projects** — when the current working directory does not match any existing collection, the picker does not suggest creating one named after the project.
+
+This spec adds all three, and tightens collection-name validation to keep the registry's naming scheme consistent.
+
+## Goals
+
+- Let the user create a collection without leaving the picker.
+- Let the user opt out of collections entirely.
+- Suggest a project-named collection (either existing or new) based on the working directory.
+- Lock down collection naming to `^[a-z0-9_-]+$` everywhere (picker, web UI, backend), and migrate existing names to match.
+
+## Non-Goals
+
+- Multi-select in the terminal picker — stays single-select (web `/collections/pick` page remains multi-select separately).
+- Replacing the `AskUserQuestion`-based `/skillnote:collection` slash command with a different mechanism. It gets parity updates, not a rewrite.
+- Changes to the web `/collections/pick` multi-select page.
+- Fuzzy/partial matching of folder names against collections — only case-insensitive exact match.
+- Concurrent-picker coordination.
+
+## Touch Points
+
+### Primary (picker UX)
+
+- **`plugin/bin/skillnote-pick`** — main curses picker and `pick_fallback` non-tty fallback.
+  - Replace `★` marker with `(Recommended)` bracketed label (Claude-Code native style).
+  - Add dynamic `+ Create 'X'` row (surfaced when the search query is a valid slug and does not match any existing collection; also surfaced as the top row when `basename(cwd)` produces a valid slug with no existing match).
+  - Add pinned `⊘ Skip (Ctrl+K)` row below the scrollable list area, always visible.
+  - Bind `Ctrl+K` as Skip hotkey.
+  - Add Skip confirmation modal.
+  - Add name-conflict mini-prompt for Create collisions.
+
+- **`plugin/skills/collection/SKILL.md`** — slash-command picker (AskUserQuestion-based).
+  - Add `Create new collection…` option (when chosen, skill asks user to type a name in a follow-up text turn; validates against the shared rule and POSTs to `/v1/collections`; on 409 reuses the existing collection).
+  - Add `Skip (use no collections)` option (when chosen, writes `{"collections": []}` and runs sync). No confirmation prompt here — AskUserQuestion itself is already a deliberate selection step, so adding a second prompt would be noise.
+  - For the recommended collection, append ` · Recommended` to its existing `description` field (which today carries `"{count} skills"`). Result: `"12 skills · Recommended"`. No reordering needed; AskUserQuestion lists options in the order given, so the skill places the recommended option first.
+  - No `Ctrl+K` or hotkeys here — hotkeys are a curses-only concern. The slash command is a pure multiple-choice UI.
+
+### Validation
+
+- **`backend/app/validators/collection_validator.py`** — add regex rule `^[a-z0-9_-]+$` alongside existing length/newline/XML checks.
+- **`src/lib/collection-validation.ts`** (new) — mirror backend rule for frontend use.
+- **`src/components/collections/NewCollectionModal.tsx`** — wire validator; show inline error and disable Create button when invalid.
+- **`src/components/collections/CollectionPicker.tsx`** — gate `canCreate` on slug validity; disable `+ Create 'X'` row when query fails validation.
+
+### Migration
+
+- **`backend/alembic/versions/0011_slugify_collection_names.py`** (new) — slugify all existing collection names; update all skill records' embedded `collections` arrays.
+
+### Tests
+
+- `backend/tests/test_collection_validator.py` (new)
+- `backend/tests/test_migration_0011_slugify.py` (new)
+- `plugin/tests/test_skillnote_pick_helpers.py` (new)
+- `src/lib/__tests__/collection-validation.test.ts` (new)
+- `e2e/collection-validation.spec.ts` (new)
+
+## User Flow (Terminal Picker)
+
+### Startup
+
+1. `skillnote-pick` runs pre-`claude`, fetches `GET /v1/collections`.
+2. Computes `folder_raw = basename(cwd)` and `folder_slug = slugify(folder_raw)` (same algorithm as the migration).
+3. Classifies into one of three recommendation states:
+   - **Match:** `folder_raw.lower()` equals an existing collection name (case-insensitive) → that row gets `(Recommended)` label and sorts to top.
+   - **Create-suggestion:** no match, but `folder_slug` is non-empty → top row becomes `+ Create '{folder_slug}' (Recommended)`. Display uses the slugified form so the suggested name is always valid.
+   - **None:** no match and `folder_slug` is empty → no recommendation; list shows existing collections only.
+
+### Interactions
+
+| Action | Effect |
+|---|---|
+| Type in search box | Filters existing collections by case-insensitive substring match on name. Separately, if the filtered list is empty **and** `slugify(query)` is non-empty **and** no existing collection name equals `slugify(query)`, append `+ Create '{slugify(query)}'` row. Example: user types `My App` → filter shows nothing → create row shows `+ Create 'my-app'`. |
+| Enter on existing collection | Write `{"collections": [name]}` to `.skillnote.json`; run sync; exit. |
+| Enter on `+ Create 'X'` | POST `/v1/collections` with name=X. On success → write `.skillnote.json`, run sync, exit. On 409 conflict → show inline Y/N prompt *"'X' already exists with N skills. Activate it? [Y/N]"*. Y → activate existing; N → return to search with query preserved. |
+| Enter on pinned Skip row OR `Ctrl+K` | Show confirmation modal *"Are you sure you want to skip?"* with `[Y] Yes [N] Cancel`. Y/Enter → write `{"collections": []}`, clean `.claude/skills/`, exit. N/Esc → dismiss, return to picker. |
+| Esc on picker | Cancel; `.skillnote.json` unchanged. |
+
+### Layout
+
+```
+  ┌ type to search... ┐
+
+  ❯ 1. frontend (Recommended)  12
+    2. backend                  8
+    3. devops                   3
+    … scrolls for longer lists …
+
+  ─────
+    ⊘ Skip (Ctrl+K)
+    ↑/↓ navigate · ↵ select · esc cancel
+```
+
+Skip is always visible regardless of list length. Recommended collection (or `+ Create '{folder}' (Recommended)` row when no match) sorts to the top of the list area.
+
+### Fallback (non-curses) picker
+
+`pick_fallback()` gets equivalent options as plain numbered input:
+
+```
+  ✦ S K I L L N O T E — Pick a collection
+
+    1. frontend  (Recommended)  12 skills
+    2. backend                   8 skills
+    3. devops                    3 skills
+    C. Create new collection
+    S. Skip (use no collections)
+
+  > _
+```
+
+- Numeric input selects a collection.
+- `C` followed by a name on next prompt → create flow.
+- `S` → Skip, with the same confirmation phrasing (`Are you sure you want to skip? [Y/N]`).
+
+## Validation Rules
+
+Single shared rule across backend, frontend, and picker:
+
+- Pattern: `^[a-z0-9_-]+$`
+- Length: 1–128 characters (after trim)
+- Existing checks retained: no newlines, no XML tags (defense-in-depth)
+
+### Enforcement sites
+
+| Site | Behavior |
+|---|---|
+| `backend/app/validators/collection_validator.py` | Return error list; POST `/v1/collections` returns 400 with message when rule fails. |
+| `src/lib/collection-validation.ts` (new) | Pure function, mirror of backend. |
+| `NewCollectionModal.tsx` | Inline error below input (`AlertCircle` + red text matching the existing `nameError` pattern at `NewCollectionModal.tsx:91-96`); Create button disabled while invalid. |
+| `CollectionPicker.tsx` (inline web picker) | `canCreate` memo gated on slug validity; `+ Create 'X'` option hidden when invalid. |
+| `skillnote-pick` (curses) | The `+ Create 'X'` row is displayed only when the condition in the User Flow table holds (filter empty, `slugify(query)` non-empty, no existing match). Invalid queries produce no row and no popup — silent. The displayed name is always the slugified form. |
+
+## Slugify Migration (`0011_slugify_collection_names.py`)
+
+### Algorithm
+
+```
+slug(name) =
+  lowercase →
+  replace runs of [^a-z0-9_-]+ with "-" →
+  collapse consecutive "-" →
+  strip leading/trailing "-" →
+  truncate to 128 chars
+```
+
+Empty result (e.g. `"!!!"` → `""`) falls back to `collection-{id}` where `{id}` is the row's primary key.
+
+### Collision resolution
+
+When two different names normalize to the same slug, append `-2`, `-3`, etc. Ordering is deterministic:
+
+- Primary: ascending `created_at`
+- Tiebreaker: ascending original name
+
+Example: `[Frontend, "frontend-", frontend_]` (created in that order) → `[frontend, frontend-2, frontend-3]`.
+
+### Steps
+
+1. Inside a single transaction:
+   1. SELECT all distinct collection names from `collections` table + from skills' embedded `collections` arrays.
+   2. Build rename map `{old_name → new_slug}`, resolving collisions.
+   3. `UPDATE collections SET name = new_slug` for each changed entry.
+   4. For each skill whose `collections` array contains any renamed name, rewrite that array.
+2. Commit.
+
+### Properties
+
+- **Idempotent:** if all names already satisfy the regex, rename map is empty and migration is a no-op.
+- **Downgrade:** `pass` (no-op). Original casing/punctuation cannot be recovered without a pre-migration stash; documented.
+- **Partial failure:** the transaction prevents partial state; Alembic rolls back cleanly.
+
+## Error Handling
+
+| Failure | Handling |
+|---|---|
+| API unreachable at picker start | Preserve current behavior: stderr `"could not reach API at http://{host}:8082"`, exit without picker. |
+| API unreachable during Create | Curses: one-line toast `"Create failed — API unreachable. Press any key."` at bottom; return to search with query preserved. Web New Collection modal: existing offline fallback (local-only save) retained for non-picker flows. |
+| Invalid slug in picker query | `+ Create 'X'` row hidden silently. No popup. |
+| Invalid slug in web modal / picker | Inline error under input; Create button disabled. |
+| 409 name conflict on create | Inline Y/N prompt (see user flow). Y activates existing, N returns to search with query preserved. |
+| `.skillnote.json` write fails (EACCES) | Preserve current `PermissionError` branch in both Skip and normal-pick paths. |
+| Sync script failure | Preserve current silent exit. Next `claude` launch retries. |
+| Migration interrupted mid-run | Single transaction ensures rollback; no partial rename state. |
+| Migration produces empty slug | Fallback `collection-{id}`, WARN-level log entry during migration for operator audit. |
+| Skip when already on empty collection | Confirm modal still shown; confirm is a no-op exit. No special branch. |
+| Concurrent pickers on same project | Last-writer-wins on `.skillnote.json`. No locking. |
+
+## Testing
+
+### Backend (pytest)
+
+- `backend/tests/test_collection_validator.py`:
+  - Valid: `frontend`, `my-app_2`, `a`, 128-char boundary.
+  - Invalid: `Frontend`, `my app`, `foo!`, empty, 129-char, newline/XML (preserved).
+- `backend/tests/test_migration_0011_slugify.py`:
+  - `test_basic_slugify` — seed `[Frontend, "lp assessment", my-app, "!!!"]` + skills referencing them → run migration → assert names become `[frontend, lp-assessment, my-app, collection-{id}]` and all skill records updated.
+  - `test_collision_resolution` — seed `[Frontend, "frontend-", frontend_]` in order → assert `[frontend, frontend-2, frontend-3]`.
+  - `test_idempotent` — run twice; second run changes nothing.
+
+### Frontend
+
+- `src/lib/__tests__/collection-validation.test.ts` — unit tests mirroring backend regex.
+- `e2e/collection-validation.spec.ts` — Playwright: New Collection modal rejects `Frontend`, accepts `frontend`; picker's inline create path follows same rules.
+
+### Picker (Python helpers only)
+
+Extract pure helpers into `plugin/bin/skillnote-pick` (exposed for import):
+- `_slugify(name) -> str`
+- `_is_valid_slug(name) -> bool`
+- `_resolve_recommendation(folder, existing) -> Literal['pick', 'create', 'none'], idx_or_slug`
+
+`plugin/tests/test_skillnote_pick_helpers.py` unit-tests these. Curses rendering is not tested automatically.
+
+### Manual QA (documented, not automated)
+
+- `/skillnote:collection` slash command: verify Create and Skip options appear; verify Skip clears `.skillnote.json`.
+- Terminal picker: resize terminal below `COMPACT_THRESHOLD` (70 cols) and verify Skip row stays visible.
+- Skip confirmation modal: verify Y and Enter both confirm; N and Esc both dismiss.
+
+## Out of Scope
+
+- Curses rendering pixel-perfection.
+- Cross-platform terminal sizing edge cases beyond what `skillnote-pick` handles today.
+- Retroactive rename notification to users (migration just runs on deploy).
+- Multi-project `.skillnote.json` templates.
+
+## Open Questions
+
+None. All UX and implementation questions resolved during brainstorming.
+
+## Success Criteria
+
+- User can start `claude` in a new project directory, see a `+ Create '{folder}' (Recommended)` row at the top of the picker, press Enter, and have a matching collection created and activated without leaving the terminal.
+- User can press `Ctrl+K` (or navigate to the pinned Skip row), confirm the modal, and have `.skillnote.json` written with `{"collections": []}` and all local skills cleaned.
+- `POST /v1/collections` with name `Frontend` returns a 400 with a clear validation message; `frontend` succeeds.
+- After migration, every collection name in the database matches `^[a-z0-9_-]+$`, and all skill records reference the post-migration names.
+- Running the migration twice is a no-op on the second run.

--- a/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
+++ b/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
@@ -52,8 +52,8 @@ This spec adds all three, and tightens collection-name validation to keep the re
 
 ### Validation
 
-- **`backend/app/validators/collection_validator.py`** — add regex rule `^[a-z0-9_-]+$` and reserved-word check (`anthropic`, `claude`, matching `src/lib/skill-validation.ts:7`) alongside existing length/newline/XML checks. This validator is already wired into `POST /v1/collections` via `backend/app/schemas/collection.py:19-25`, so no schema change needed there.
-- **`backend/app/schemas/skill.py`** — extend the existing `SkillCreate.check_collections` field_validator (lines 64-70) so that, after the current "at least one collection required" check, it also runs each entry through `validate_collection_name`. Apply the same change to `SkillUpdate.collections`. Closes the skill-push path that currently lets arbitrary strings land in `skills.collections[]`.
+- **`backend/app/validators/collection_validator.py`** — add regex rule `^[a-z0-9_-]+$` and reserved-word check alongside existing length/newline/XML checks. Import `RESERVED_WORDS` from `backend/app/validators/skill_validator.py:8` to avoid duplicating the list. This validator is already wired into `POST /v1/collections` via `backend/app/schemas/collection.py:19-25`, so no change needed there.
+- **`backend/app/api/skills.py`** (not schema) — add per-name validation in the handler **after** `canonicalize_collection_names(...)` in both `create_skill` (around line 305) and `update_skill` (around line 371). Schema-level validation would break tolerance: today a client posts `collections: ["Frontend"]`, Pydantic passes the "at least one" check, then the handler calls `canonicalize_collection_names` which maps `Frontend` → `frontend` (the canonical stored form). If we validated at the schema layer, `Frontend` would 422 before canonicalization ever runs. Correct placement: validate the canonical forms, so clients keep their case-insensitive tolerance while truly new invalid names (e.g. `"Bad Name"`) are still rejected. Return `api_error(422, "COLLECTION_NAME_INVALID", ...)` on failure, matching the pattern used by `validate_collection_skill_count` errors at `skills.py:311`.
 - **`src/lib/collection-validation.ts`** (new) — mirror backend rule for frontend use; export `validateCollectionName`, `normalizeCollectionName`, `slugFromCollectionName` following the pattern in `src/lib/skill-validation.ts`.
 - **`src/components/collections/NewCollectionModal.tsx`** — wire validator; show inline error and disable Create button when invalid.
 - **`src/components/collections/CollectionPicker.tsx`** — gate `canCreate` on slug validity; disable `+ Create 'X'` row when query fails validation. The existing `persistCollection` offline-fallback helper (lines 35-43) is only reached via `add('__create__')` after `canCreate === true`, so the `canCreate` gate is the single enforcement point — no separate validation needed inside `persistCollection`.
@@ -109,7 +109,7 @@ Frontend unit tests for the pure validator are intentionally omitted — `packag
     ↑/↓ navigate · ↵ select · esc cancel
 ```
 
-Skip is always visible regardless of list length. Recommended collection (or `+ Create '{folder}' (Recommended)` row when no match) sorts to the top of the list area.
+Skip is always visible regardless of list length. Recommended collection (or `+ Create '{folder_slug}' (Recommended)` row when no match) sorts to the top of the list area.
 
 ### Fallback (non-curses) picker
 
@@ -128,8 +128,9 @@ Skip is always visible regardless of list length. Recommended collection (or `+ 
 ```
 
 - Numeric input selects a collection.
-- `C` followed by a name on next prompt → create flow.
+- `C` followed by a name on next prompt → create flow. On 409 conflict → same `"'X' already exists with N skills. Activate it? [Y/N]"` prompt as the curses path.
 - `S` → Skip, with the same confirmation phrasing (`Are you sure you want to skip? [Y/N]`).
+- When `folder_slug` is non-empty and has no existing match, the fallback prepends a `0. + Create '{folder_slug}' (Recommended)` entry above the numbered collections so keyboard parity with the curses picker is preserved.
 
 ## Validation Rules
 
@@ -144,7 +145,7 @@ Single shared rule across backend, frontend, and picker:
 
 | Site | Behavior |
 |---|---|
-| `backend/app/validators/collection_validator.py` | Return error list; the Pydantic `check_name` field_validator in `schemas/collection.py:19-25` raises `ValueError`, which FastAPI surfaces as **422 Unprocessable Entity** (same pattern `skill-push/SKILL.md:106` documents). |
+| `backend/app/validators/collection_validator.py` | Return error list. Called in two places: (1) `POST /v1/collections` via the existing Pydantic `check_name` field_validator at `schemas/collection.py:19-25` — raises `ValueError` → FastAPI surfaces as **422 Unprocessable Entity**. (2) `POST /v1/skills` and `PATCH /v1/skills/{slug}` handlers — called after `canonicalize_collection_names()` (see `skills.py:305` and `:371`). Returns `api_error(422, "COLLECTION_NAME_INVALID", ...)` on failure. |
 | `src/lib/collection-validation.ts` (new) | Pure function, mirror of backend. |
 | `NewCollectionModal.tsx` | Inline error below input (`AlertCircle` + red text matching the existing `nameError` pattern at `NewCollectionModal.tsx:91-96`); Create button disabled while invalid. |
 | `CollectionPicker.tsx` (inline web picker) | `canCreate` memo gated on slug validity; `+ Create 'X'` option hidden when invalid. |
@@ -217,6 +218,10 @@ Example: `[Frontend, "frontend-", frontend_]` (created in that order) → `[fron
   - `test_collision_resolution` — seed `[Frontend, "frontend-", frontend_]` in order → assert `[frontend, frontend-2, frontend-3]`.
   - `test_idempotent` — run twice; second run changes nothing.
   - `test_skill_references_updated` — skills whose `collections` arrays contain old names get rewritten to new names.
+- `backend/tests/integration/test_skills_api.py` (extend if exists, else new):
+  - `test_create_skill_rejects_invalid_collection_name` — POST `/v1/skills` with `collections: ["Bad Name"]` → 422 `COLLECTION_NAME_INVALID`.
+  - `test_create_skill_accepts_canonicalizable_variant` — POST with `collections: ["Frontend"]` when `frontend` exists → 201 (canonicalization + validation pipeline works together).
+  - `test_update_skill_rejects_invalid_collection_name` — same check on PATCH path.
 
 ### Frontend
 

--- a/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
+++ b/docs/superpowers/specs/2026-04-17-collection-picker-options-design.md
@@ -52,22 +52,25 @@ This spec adds all three, and tightens collection-name validation to keep the re
 
 ### Validation
 
-- **`backend/app/validators/collection_validator.py`** — add regex rule `^[a-z0-9_-]+$` alongside existing length/newline/XML checks.
-- **`src/lib/collection-validation.ts`** (new) — mirror backend rule for frontend use.
+- **`backend/app/validators/collection_validator.py`** — add regex rule `^[a-z0-9_-]+$` and reserved-word check (`anthropic`, `claude`, matching `src/lib/skill-validation.ts:7`) alongside existing length/newline/XML checks. This validator is already wired into `POST /v1/collections` via `backend/app/schemas/collection.py:19-25`, so no schema change needed there.
+- **`backend/app/schemas/skill.py`** — add a `field_validator` on `SkillCreate.collections` / `SkillUpdate.collections` that runs each entry through `validate_collection_name`. Closes the skill-push path that currently lets arbitrary strings land in `skills.collections[]`.
+- **`src/lib/collection-validation.ts`** (new) — mirror backend rule for frontend use; export `validateCollectionName`, `normalizeCollectionName`, `slugFromCollectionName` following the pattern in `src/lib/skill-validation.ts`.
 - **`src/components/collections/NewCollectionModal.tsx`** — wire validator; show inline error and disable Create button when invalid.
-- **`src/components/collections/CollectionPicker.tsx`** — gate `canCreate` on slug validity; disable `+ Create 'X'` row when query fails validation.
+- **`src/components/collections/CollectionPicker.tsx`** — gate `canCreate` on slug validity; disable `+ Create 'X'` row when query fails validation. Also apply validation to the offline-fallback write at lines 37-42 so local state cannot drift from backend rules.
+- **`plugin/skills/skill-push/SKILL.md`** — update Step 4 to instruct the user that new collection names must match `^[a-z0-9_-]+$`. Informational guidance only; the backend `SkillCreate` validator is the actual enforcement point.
 
 ### Migration
 
-- **`backend/alembic/versions/0011_slugify_collection_names.py`** (new) — slugify all existing collection names; update all skill records' embedded `collections` arrays.
+- **`backend/alembic/versions/0012_slugify_collection_names.py`** (new) — `revision = '0012_slugify_collection_names'`, `down_revision = '0011_collections_table'`. Slugifies all existing collection names and updates all skill records' embedded `collections` arrays.
 
 ### Tests
 
-- `backend/tests/test_collection_validator.py` (new)
-- `backend/tests/test_migration_0011_slugify.py` (new)
-- `plugin/tests/test_skillnote_pick_helpers.py` (new)
-- `src/lib/__tests__/collection-validation.test.ts` (new)
-- `e2e/collection-validation.spec.ts` (new)
+- `backend/tests/unit/test_collection_validator.py` (**extend** — file already exists) — add regex + reserved-word cases.
+- `backend/tests/integration/test_migration_0012_slugify.py` (new) — seeded migration run + idempotency + collision test.
+- `plugin/tests/test_skillnote_pick_helpers.py` (new) — pure-function unit tests for `_slugify`, `_is_valid_slug`, `_resolve_recommendation`.
+- `e2e/collection-validation.spec.ts` (new) — Playwright coverage for New Collection modal + inline CollectionPicker create path.
+
+Frontend unit tests for the pure validator are intentionally omitted — `package.json` does not ship `vitest`/`jest`, and the Playwright e2e proves the same behavior without introducing a new test framework for a 10-line regex.
 
 ## User Flow (Terminal Picker)
 
@@ -133,6 +136,7 @@ Single shared rule across backend, frontend, and picker:
 
 - Pattern: `^[a-z0-9_-]+$`
 - Length: 1–128 characters (after trim)
+- Reserved words (blocked as substrings): `anthropic`, `claude` — matches `src/lib/skill-validation.ts:7`
 - Existing checks retained: no newlines, no XML tags (defense-in-depth)
 
 ### Enforcement sites
@@ -145,7 +149,7 @@ Single shared rule across backend, frontend, and picker:
 | `CollectionPicker.tsx` (inline web picker) | `canCreate` memo gated on slug validity; `+ Create 'X'` option hidden when invalid. |
 | `skillnote-pick` (curses) | The `+ Create 'X'` row is displayed only when the condition in the User Flow table holds (filter empty, `slugify(query)` non-empty, no existing match). Invalid queries produce no row and no popup — silent. The displayed name is always the slugified form. |
 
-## Slugify Migration (`0011_slugify_collection_names.py`)
+## Slugify Migration (`0012_slugify_collection_names.py`)
 
 ### Algorithm
 
@@ -158,7 +162,7 @@ slug(name) =
   truncate to 128 chars
 ```
 
-Empty result (e.g. `"!!!"` → `""`) falls back to `collection-{id}` where `{id}` is the row's primary key.
+Empty result (e.g. `"!!!"` → `""`) falls back to `collection-{hash8}` where `{hash8}` is the first 8 hex chars of `sha1(original_name)`. The `collections` table uses `name` as its primary key (`backend/app/db/models/collection.py:12`) — there is no surrogate `id` column to fall back on. Hash-based suffix is deterministic, collision-safe in practice, and preserves migration reproducibility.
 
 ### Collision resolution
 
@@ -174,8 +178,8 @@ Example: `[Frontend, "frontend-", frontend_]` (created in that order) → `[fron
 1. Inside a single transaction:
    1. SELECT all distinct collection names from `collections` table + from skills' embedded `collections` arrays.
    2. Build rename map `{old_name → new_slug}`, resolving collisions.
-   3. `UPDATE collections SET name = new_slug` for each changed entry.
-   4. For each skill whose `collections` array contains any renamed name, rewrite that array.
+   3. `UPDATE collections SET name = new_slug` for each changed entry. Because `name` is the primary key and `ix_collections_name_ci` enforces case-insensitive uniqueness (added in `0011_collections_table.py:25`), updates must be ordered so that no intermediate state violates the index. Simplest approach: apply all renames via a single `UPDATE ... FROM (VALUES ...) AS map` statement that Postgres executes atomically.
+   4. For each skill whose `collections` array contains any renamed name, rewrite that array (also via a single set-based UPDATE using `array_replace` chained per rename pair, or a procedural loop if simpler).
 2. Commit.
 
 ### Properties
@@ -204,18 +208,20 @@ Example: `[Frontend, "frontend-", frontend_]` (created in that order) → `[fron
 
 ### Backend (pytest)
 
-- `backend/tests/test_collection_validator.py`:
+- `backend/tests/unit/test_collection_validator.py` (**extend** — file already exists):
   - Valid: `frontend`, `my-app_2`, `a`, 128-char boundary.
-  - Invalid: `Frontend`, `my app`, `foo!`, empty, 129-char, newline/XML (preserved).
-- `backend/tests/test_migration_0011_slugify.py`:
-  - `test_basic_slugify` — seed `[Frontend, "lp assessment", my-app, "!!!"]` + skills referencing them → run migration → assert names become `[frontend, lp-assessment, my-app, collection-{id}]` and all skill records updated.
+  - Invalid: `Frontend`, `my app`, `foo!`, empty, 129-char, names containing reserved words (`anthropic`, `claude`), newline/XML (preserved).
+- `backend/tests/integration/test_migration_0012_slugify.py` (new):
+  - `test_basic_slugify` — seed `[Frontend, "lp assessment", my-app, "!!!"]` + skills referencing them → run migration → assert names become `[frontend, lp-assessment, my-app, collection-{hash8}]` and all skill records updated.
   - `test_collision_resolution` — seed `[Frontend, "frontend-", frontend_]` in order → assert `[frontend, frontend-2, frontend-3]`.
   - `test_idempotent` — run twice; second run changes nothing.
+  - `test_skill_references_updated` — skills whose `collections` arrays contain old names get rewritten to new names.
 
 ### Frontend
 
-- `src/lib/__tests__/collection-validation.test.ts` — unit tests mirroring backend regex.
-- `e2e/collection-validation.spec.ts` — Playwright: New Collection modal rejects `Frontend`, accepts `frontend`; picker's inline create path follows same rules.
+- `e2e/collection-validation.spec.ts` (new) — Playwright: New Collection modal rejects `Frontend`, accepts `frontend`; picker's inline create path follows same rules; offline-fallback write also rejects invalid names.
+
+No frontend unit tests — `package.json` does not ship `vitest`/`jest`, and Playwright e2e proves the same regex behavior without introducing a new test framework.
 
 ### Picker (Python helpers only)
 

--- a/e2e/collection-validation.spec.ts
+++ b/e2e/collection-validation.spec.ts
@@ -158,4 +158,61 @@ test.describe('Collection name validation', () => {
     expect(meta).not.toBeNull()
     expect(JSON.parse(meta as string)['offline-save']).toBeTruthy()
   })
+
+  test('CollectionPicker inline create — 409 duplicate shows toast, no chip', async ({ page }) => {
+    // Mock /v1/collections: GET returns an existing collection, POST always 409s
+    await page.route('**/v1/collections', async route => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'COLLECTION_EXISTS', message: 'Collection "dup-inline" already exists' },
+          }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200, contentType: 'application/json',
+          body: JSON.stringify([{ name: 'existing-col', count: 0, description: '' }]),
+        })
+      }
+    })
+    // Skills list is empty so the "new skill" route renders cleanly
+    await page.route('**/v1/skills*', route => route.fulfill({
+      status: 200, contentType: 'application/json', body: '[]',
+    }))
+
+    // /skills/new renders SkillEditTab in create mode, which embeds CollectionPicker
+    await page.goto('/skills/new')
+
+    // Inline CollectionPicker's trigger reads "Add collection" when no chips selected
+    const addBtn = page.getByRole('button', { name: /^add collection$/i }).first()
+    await expect(addBtn).toBeVisible({ timeout: 5000 })
+    await addBtn.click()
+
+    // Type a name that will 409 on create
+    const search = page.getByPlaceholder(/search or create/i)
+    await search.fill('dup-inline')
+
+    // The "+ Create" row should appear — click it
+    const createRow = page.getByRole('button', { name: /create ["\u201c]dup-inline["\u201d]/i })
+    await expect(createRow).toBeVisible({ timeout: 2000 })
+    await createRow.click()
+
+    // Toast should appear with "already exists" content
+    await expect(page.getByText(/already exists/i).first()).toBeVisible({ timeout: 5000 })
+
+    // The chip "dup-inline" must NOT be rendered, because the API rejected.
+    // Look specifically within the selected-chips row (the CollectionPicker root)
+    // — the dropdown itself may still contain the text in the create-row button.
+    // After rejection, dropdown stays open, so assert there is no chip with a
+    // Remove button labelled for "dup-inline".
+    await expect(
+      page.getByRole('button', { name: /remove dup-inline/i })
+    ).toHaveCount(0)
+
+    // localStorage should NOT contain a ghost entry for dup-inline
+    const meta = await page.evaluate(() => localStorage.getItem('skillnote:collections-meta'))
+    expect(meta === null || !JSON.parse(meta)['dup-inline']).toBe(true)
+  })
 })

--- a/e2e/collection-validation.spec.ts
+++ b/e2e/collection-validation.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * E2E: Collection name validation in NewCollectionModal
+ *
+ * All API calls are mocked via page.route() so tests run without a backend.
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.describe('Collection name validation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Skills list (collections page calls syncSkillsFromApi on mount)
+    await page.route('**/v1/skills', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: '[]',
+      })
+    })
+
+    // Mock the collections list
+    await page.route('**/v1/collections', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ name: 'frontend', count: 0, description: '' }]),
+      })
+    })
+  })
+
+  test('NewCollectionModal rejects uppercase names', async ({ page }) => {
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const name = page.getByPlaceholder(/e\.g\./i)
+    await name.fill('Frontend')
+    await name.blur()
+    await expect(page.getByText(/lowercase/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  test('NewCollectionModal accepts lowercase slug', async ({ page }) => {
+    await page.route('**/v1/collections', async route => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            name: 'devops', description: '',
+            created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+          }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200, contentType: 'application/json',
+          body: JSON.stringify([{ name: 'frontend', count: 0, description: '' }]),
+        })
+      }
+    })
+
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const name = page.getByPlaceholder(/e\.g\./i)
+    await name.fill('devops')
+    await expect(page.getByRole('button', { name: /^create$/i })).toBeEnabled()
+  })
+
+  test('NewCollectionModal rejects reserved word', async ({ page }) => {
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const name = page.getByPlaceholder(/e\.g\./i)
+    await name.fill('claude-stuff')
+    await name.blur()
+    await expect(page.getByText(/reserved word/i)).toBeVisible()
+    await expect(page.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+})

--- a/e2e/collection-validation.spec.ts
+++ b/e2e/collection-validation.spec.ts
@@ -92,4 +92,70 @@ test.describe('Collection name validation', () => {
     // The regex error fires first (uppercase S and <) — that's OK, still rejected
     await expect(dialog.getByRole('button', { name: /^create$/i })).toBeDisabled()
   })
+
+  test('NewCollectionModal surfaces 409 duplicate as inline error, modal stays open', async ({ page }) => {
+    let postAttempts = 0
+    await page.route('**/v1/collections', async route => {
+      if (route.request().method() === 'POST') {
+        postAttempts++
+        await route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            error: { code: 'COLLECTION_EXISTS', message: 'Collection "dup-test" already exists' },
+          }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200, contentType: 'application/json',
+          body: JSON.stringify([{ name: 'dup-test', count: 0, description: '' }]),
+        })
+      }
+    })
+    await page.route('**/v1/skills*', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const dialog = page.getByRole('dialog')
+    const name = dialog.getByPlaceholder(/e\.g\./i)
+    await name.fill('dup-test')
+    await dialog.getByRole('button', { name: /^create$/i }).click()
+
+    // Modal must stay open
+    await expect(dialog).toBeVisible()
+    // Inline error visible
+    await expect(dialog.getByText(/already exists/i)).toBeVisible()
+    // localStorage ghost NOT written
+    const meta = await page.evaluate(() => localStorage.getItem('skillnote:collections-meta'))
+    expect(meta === null || !JSON.parse(meta)['dup-test']).toBe(true)
+    expect(postAttempts).toBe(1)
+  })
+
+  test('NewCollectionModal falls back to local save on network error only', async ({ page }) => {
+    await page.route('**/v1/collections', async route => {
+      if (route.request().method() === 'POST') {
+        await route.abort('failed')  // simulate network error
+      } else {
+        await route.fulfill({
+          status: 200, contentType: 'application/json',
+          body: JSON.stringify([]),
+        })
+      }
+    })
+    await page.route('**/v1/skills*', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }))
+
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const dialog = page.getByRole('dialog')
+    const name = dialog.getByPlaceholder(/e\.g\./i)
+    await name.fill('offline-save')
+    await dialog.getByRole('button', { name: /^create$/i }).click()
+
+    // Modal closes (offline fallback preserves work)
+    await expect(dialog).not.toBeVisible({ timeout: 5000 })
+    // localStorage DOES contain the entry
+    const meta = await page.evaluate(() => localStorage.getItem('skillnote:collections-meta'))
+    expect(meta).not.toBeNull()
+    expect(JSON.parse(meta as string)['offline-save']).toBeTruthy()
+  })
 })

--- a/e2e/collection-validation.spec.ts
+++ b/e2e/collection-validation.spec.ts
@@ -30,16 +30,19 @@ test.describe('Collection name validation', () => {
   test('NewCollectionModal rejects uppercase names', async ({ page }) => {
     await page.goto('/collections')
     await page.getByRole('button', { name: /new collection/i }).first().click()
-    const name = page.getByPlaceholder(/e\.g\./i)
+    const dialog = page.getByRole('dialog')
+    const name = dialog.getByPlaceholder(/e\.g\./i)
     await name.fill('Frontend')
     await name.blur()
-    await expect(page.getByText(/lowercase/i)).toBeVisible()
-    await expect(page.getByRole('button', { name: /^create$/i })).toBeDisabled()
+    await expect(dialog.getByText(/lowercase/i)).toBeVisible()
+    await expect(dialog.getByRole('button', { name: /^create$/i })).toBeDisabled()
   })
 
-  test('NewCollectionModal accepts lowercase slug', async ({ page }) => {
+  test('NewCollectionModal accepts lowercase slug and submits', async ({ page }) => {
+    let postedBody: unknown = null
     await page.route('**/v1/collections', async route => {
       if (route.request().method() === 'POST') {
+        postedBody = JSON.parse(route.request().postData() ?? '{}')
         await route.fulfill({
           status: 201,
           contentType: 'application/json',
@@ -58,18 +61,35 @@ test.describe('Collection name validation', () => {
 
     await page.goto('/collections')
     await page.getByRole('button', { name: /new collection/i }).first().click()
-    const name = page.getByPlaceholder(/e\.g\./i)
+    const dialog = page.getByRole('dialog')
+    const name = dialog.getByPlaceholder(/e\.g\./i)
     await name.fill('devops')
-    await expect(page.getByRole('button', { name: /^create$/i })).toBeEnabled()
+    const createBtn = dialog.getByRole('button', { name: /^create$/i })
+    await expect(createBtn).toBeEnabled()
+    await createBtn.click()
+    await expect(dialog).not.toBeVisible()
+    expect(postedBody).toEqual({ name: 'devops', description: '' })
   })
 
   test('NewCollectionModal rejects reserved word', async ({ page }) => {
     await page.goto('/collections')
     await page.getByRole('button', { name: /new collection/i }).first().click()
-    const name = page.getByPlaceholder(/e\.g\./i)
+    const dialog = page.getByRole('dialog')
+    const name = dialog.getByPlaceholder(/e\.g\./i)
     await name.fill('claude-stuff')
     await name.blur()
-    await expect(page.getByText(/reserved word/i)).toBeVisible()
-    await expect(page.getByRole('button', { name: /^create$/i })).toBeDisabled()
+    await expect(dialog.getByText(/reserved word/i)).toBeVisible()
+    await expect(dialog.getByRole('button', { name: /^create$/i })).toBeDisabled()
+  })
+
+  test('NewCollectionModal rejects XML tags', async ({ page }) => {
+    await page.goto('/collections')
+    await page.getByRole('button', { name: /new collection/i }).first().click()
+    const dialog = page.getByRole('dialog')
+    const name = dialog.getByPlaceholder(/e\.g\./i)
+    await name.fill('<script>')
+    await name.blur()
+    // The regex error fires first (uppercase S and <) — that's OK, still rejected
+    await expect(dialog.getByRole('button', { name: /^create$/i })).toBeDisabled()
   })
 })

--- a/install.sh
+++ b/install.sh
@@ -103,13 +103,84 @@ compose() {
   $COMPOSE -f "$PROJECT_DIR/docker-compose.yml" "$@"
 }
 
+# ── Port availability check ──────────────────────────────────────
+# Returns: 0 if free, 1 if in use.
+# Sets PORT_HOLDER_PID and PORT_HOLDER_NAME when in use.
+check_port() {
+  local port="$1"
+  PORT_HOLDER_PID=""
+  PORT_HOLDER_NAME=""
+  # Try lsof first (macOS + most Linuxes)
+  if command -v lsof &>/dev/null; then
+    PORT_HOLDER_PID=$(lsof -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1)
+    if [ -n "$PORT_HOLDER_PID" ]; then
+      PORT_HOLDER_NAME=$(ps -p "$PORT_HOLDER_PID" -o comm= 2>/dev/null | awk '{print $1}')
+      return 1
+    fi
+    return 0
+  fi
+  # Fallback: ss (Linux)
+  if command -v ss &>/dev/null; then
+    if ss -ltn "sport = :$port" 2>/dev/null | grep -q LISTEN; then
+      PORT_HOLDER_NAME="unknown"
+      return 1
+    fi
+    return 0
+  fi
+  # No port-checker available — assume free so we don't block install.
+  return 0
+}
+
+# Prints a guided error for a port that's already in use and exits.
+port_conflict_hint() {
+  local name="$1" port="$2"
+  echo ""
+  echo -e "  ${RED}✗ Port ${port} (${name}) is already in use${NC}"
+  echo ""
+  if [ -n "${PORT_HOLDER_PID:-}" ]; then
+    echo -e "  ${DIM}Held by:${NC}  PID ${PORT_HOLDER_PID} (${PORT_HOLDER_NAME:-?})"
+    echo ""
+    echo -e "  ${BOLD}Fix options:${NC}"
+    echo -e "    ${DIM}1.${NC} Kill the running process:"
+    echo -e "       ${CYAN}kill ${PORT_HOLDER_PID}${NC}"
+    echo -e "    ${DIM}2.${NC} Or move SkillNote to a different port:"
+    case "$name" in
+      Web) echo -e "       ${CYAN}SKILLNOTE_WEB_PORT=3001 ./install.sh${NC}" ;;
+      API) echo -e "       ${CYAN}SKILLNOTE_API_PORT=8182 ./install.sh${NC}" ;;
+      MCP) echo -e "       ${CYAN}SKILLNOTE_MCP_PORT=8183 ./install.sh${NC}" ;;
+    esac
+  else
+    echo -e "  ${DIM}Install lsof or ss to see which process is holding it.${NC}"
+  fi
+  echo ""
+  exit 1
+}
+
 # ── Header ────────────────────────────────────────────────────────
 echo ""
 echo -e "  ${BOLD}S K I L L N O T E${NC}"
 echo ""
 
+# ── 0. Pre-flight: check ports are free ──────────────────────────
+# Catches the common "npm run dev still running" / "old container orphan" /
+# "another service on 8082" cases BEFORE we waste time building images.
+for port_spec in "Web:${WEB_PORT}" "API:${API_PORT}" "MCP:${MCP_PORT}"; do
+  name="${port_spec%%:*}"
+  port="${port_spec##*:}"
+  if ! check_port "$port"; then
+    # Stop any existing SkillNote containers first — they legitimately own these ports
+    # and will be recreated by compose up. Re-check after compose-down.
+    compose down 2>/dev/null || true
+    if ! check_port "$port"; then
+      port_conflict_hint "$name" "$port"
+    fi
+  fi
+done
+
 # ── 1. Stop previous SkillNote containers ─────────────────────────
-# Only stops SkillNote containers, not other Docker apps
+# Only stops SkillNote containers, not other Docker apps.
+# (Also runs during pre-flight when a port is busy, but re-run here so the
+#  "stopped" confirmation is visible on a clean install too.)
 compose down 2>/dev/null || true
 ok "Stopped previous SkillNote containers"
 
@@ -144,11 +215,36 @@ rm -f "$BUILD_LOG"
 ok "Images built"
 
 # ── 3. Start ──────────────────────────────────────────────────────
+# Capture both stdout and stderr so a bind-address-in-use or similar failure
+# gets surfaced to the user instead of the script silently exiting.
+UP_LOG=$(mktemp)
 SKILLNOTE_HOST="$SKILLNOTE_HOST" \
 SKILLNOTE_API_PORT="$API_PORT" \
 SKILLNOTE_MCP_PORT="$MCP_PORT" \
 SKILLNOTE_WEB_PORT="$WEB_PORT" \
-  compose up -d > /dev/null 2>&1
+  compose up -d > "$UP_LOG" 2>&1 || {
+  echo ""
+  echo -e "  ${RED}✗ Failed to start containers${NC}"
+  echo ""
+  echo -e "  ${DIM}Last 12 lines of output:${NC}"
+  tail -12 "$UP_LOG" | sed 's/^/    /'
+  echo ""
+  # Heuristics for the most common failures
+  if grep -qi "address already in use\|port is already allocated" "$UP_LOG"; then
+    echo -e "  ${BOLD}Likely cause:${NC} a port (${WEB_PORT}, ${API_PORT}, or ${MCP_PORT}) was freed"
+    echo -e "  between the pre-flight check and now. Re-run ${CYAN}./install.sh${NC}."
+  elif grep -qi "permission denied\|cannot connect to the docker daemon" "$UP_LOG"; then
+    echo -e "  ${BOLD}Likely cause:${NC} the container runtime needs attention."
+    echo -e "  Ensure ${CYAN}${COMPOSE%% *}${NC} daemon/machine is running."
+  else
+    echo -e "  ${BOLD}To inspect:${NC}"
+    echo -e "    ${CYAN}$COMPOSE -f docker-compose.yml logs${NC}"
+  fi
+  echo ""
+  rm -f "$UP_LOG"
+  exit 1
+}
+rm -f "$UP_LOG"
 ok "Containers started"
 
 # ── 4. Health checks ─────────────────────────────────────────────
@@ -161,7 +257,22 @@ for i in $(seq 1 60); do
     ok "API ready"
     break
   fi
-  [ "$i" -eq 60 ] && err "API failed to start. Run: $COMPOSE logs api"
+  if [ "$i" -eq 60 ]; then
+    echo ""
+    echo -e "  ${RED}✗ API didn't become healthy within 120s${NC}"
+    echo ""
+    echo -e "  ${DIM}Last 20 lines of API logs:${NC}"
+    compose logs --tail 20 api 2>/dev/null | sed 's/^/    /' || true
+    echo ""
+    echo -e "  ${BOLD}Common causes:${NC}"
+    echo -e "    ${DIM}•${NC} Database still migrating (wait + retry)"
+    echo -e "    ${DIM}•${NC} Alembic migration error — check logs above"
+    echo -e "    ${DIM}•${NC} Port ${API_PORT} bound by another process on the container-side"
+    echo ""
+    echo -e "  ${BOLD}To inspect:${NC}  ${CYAN}$COMPOSE -f docker-compose.yml logs api${NC}"
+    echo ""
+    exit 1
+  fi
   sleep 2
 done
 

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -420,9 +420,14 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
         # Selected collection for preview
         sel_name, sel_count, sel_skills = "", 0, []
         sel_is_rec = False
+        sel_is_synthetic = False
         if filtered and cur < len(filtered):
             _, orig_idx, (sel_name, sel_count, sel_skills) = filtered[cur]
-            sel_is_rec = (orig_idx == recommended)
+            sel_is_synthetic = (orig_idx == -1)
+            # Only mark as "recommended" for the right-panel suffix when this
+            # is a real matching collection (not a synthetic Create row, whose
+            # label already embeds the suffix).
+            sel_is_rec = (not sel_is_synthetic) and (orig_idx == recommended)
 
         def s(r, c, text, attr=0):
             try:
@@ -530,7 +535,12 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                     break
                 fi = window_start + vi
                 is_focused = (fi == cur)
-                is_rec = (orig_idx == recommended)
+                is_synthetic = (orig_idx == -1)  # synthetic "+ Create 'X'" row
+                # Only treat as "recommended" (for the inline suffix) when this is a
+                # real existing-collection row that matches the folder-name recommendation.
+                # Synthetic create rows already embed the suffix in `name`, so we must
+                # NOT double-draw it.
+                is_rec = (not is_synthetic) and (orig_idx == recommended)
                 at_top = (vi == 0 and window_start > 0)
                 at_bot = (vi == len(visible) - 1 and window_start + visible_count < len(filtered))
 
@@ -548,16 +558,38 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                 num = f"{fi + 1}."
                 s(row, bx + 5, num, DIM)
                 nx = bx + 5 + len(num) + 1
-                if is_focused:
-                    s(row, nx, name, ACCENT)
-                else:
-                    s(row, nx, name, DIM if not is_rec else 0)
-                if is_rec:
-                    rec_label = " (Recommended)"
-                    s(row, nx + len(name), rec_label, DIM if not is_focused else ACCENT)
 
-                cnt = str(count)
-                s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
+                # Compute the column where the count would draw (or the panel edge
+                # for synthetic rows, which have no count). Reserve 2 cols of padding
+                # before it so the name doesn't butt up against the count / divider.
+                cnt = str(count) if not is_synthetic else ""
+                if is_synthetic:
+                    count_col = bx + left_w - 1  # up to the center divider
+                else:
+                    count_col = bx + left_w - len(cnt) - 2
+                max_name_w = max(0, count_col - nx - 2)
+
+                # If this row will also draw a " (Recommended)" suffix separately,
+                # reserve room for it up front so the name-truncation leaves space.
+                suffix = " (Recommended)" if is_rec else ""
+                name_budget = max(0, max_name_w - len(suffix))
+
+                display_name = name
+                if len(display_name) > name_budget:
+                    display_name = display_name[: max(0, name_budget - 1)] + "…"
+
+                if is_focused:
+                    s(row, nx, display_name, ACCENT)
+                else:
+                    s(row, nx, display_name, DIM if not is_rec else 0)
+                if suffix:
+                    s(row, nx + len(display_name), suffix,
+                      DIM if not is_focused else ACCENT)
+
+                # Count only for real collections. Synthetic Create rows have count=0
+                # which is meaningless and collides with a long label.
+                if not is_synthetic:
+                    s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
                 row += 1
 
             # Pad remaining left rows (reserve one row for the pinned Skip entry)

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -63,42 +63,163 @@ def _resolve_recommendation(folder_raw, existing):
     return ("create", slug)
 
 
-def _confirm_skip(stdscr):
-    """Draw a centered modal and return True if user confirms."""
+def _wrap_simple(text, w):
+    """Word-wrap plain text to a list of lines of max width `w`."""
+    out = []
+    for para in text.split("\n"):
+        if not para:
+            out.append("")
+            continue
+        line = ""
+        for word in para.split(" "):
+            if not line:
+                line = word
+            elif len(line) + 1 + len(word) <= w:
+                line = f"{line} {word}"
+            else:
+                out.append(line)
+                line = word
+            # Hard-wrap any word longer than the budget
+            while len(line) > w:
+                out.append(line[:w])
+                line = line[w:]
+        out.append(line)
+    return out
+
+
+def _draw_modal(stdscr, title, body, primary, secondary, accent_color=1):
+    """Render a bordered, centered confirmation modal and return True/False.
+
+    `primary` and `secondary` are (label, keys) tuples where keys is an iterable
+    of int keycodes that resolve to the action. The primary action binds Enter
+    as a safety default so the modal always has a keyboard-only path to commit.
+    The secondary action binds Esc. Returns True if primary was chosen, False
+    for secondary. Resizes and redraws on KEY_RESIZE.
+    """
     import curses
-    curses.flushinp()  # discard any buffered type-ahead so Enter can't auto-confirm
-    box_h, box_w = 5, 40
-    while True:
+    curses.flushinp()
+    p_label, p_keys = primary
+    s_label, s_keys = secondary
+
+    # Target box width: prefer 56 cols but shrink for narrow terminals and
+    # expand (up to 70) if the title alone needs more room. We never exceed
+    # terminal width − 10 so the modal always has visible breathing room.
+    TARGET_W = 56
+    MAX_W = 72
+    MIN_W = 40
+
+    def render():
         h, w = stdscr.getmaxyx()
-        if h < box_h + 2 or w < box_w + 2:
-            # Fallback: too small for a centered modal
+        desired = max(TARGET_W, len(title) + 8)
+        # Account for the right-side keycap hint so it never wraps.
+        p_hint_len = len(p_label) + 4  # " · ↵"
+        s_hint_len = len(s_label) + 5  # " · Esc"
+        action_bar_min = 4 + p_hint_len + s_hint_len + 6  # padding + gap
+        desired = max(desired, action_bar_min)
+        box_w = min(max(desired, MIN_W), MAX_W, max(20, w - 8))
+        body_lines = []
+        for ln in body:
+            body_lines.extend(_wrap_simple(ln, box_w - 6))
+        # Structure: top · title · blank · body[…] · blank · rule · action · bottom
+        # rule = 1 row, action = 1 row
+        box_h = 6 + len(body_lines) + 2
+        # Too-small guard: status line fallback
+        if h < box_h + 2 or w < box_w + 4:
             try:
-                stdscr.addstr(max(0, h - 1), 0, " Skip? [y/N] ", curses.A_REVERSE)
+                msg = f" {title}  ({p_label[0]}/{s_label[0]}) "
+                stdscr.addstr(max(0, h - 1), 0,
+                              msg[: max(0, w - 1)], curses.A_REVERSE)
                 stdscr.clrtoeol()
                 stdscr.refresh()
             except curses.error:
                 pass
-        else:
-            y = (h - box_h) // 2
-            x = (w - box_w) // 2
-            try:
-                for i in range(box_h):
-                    stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
-                stdscr.addstr(y + 1, x + 2, "Are you sure you want to skip?", curses.A_REVERSE | curses.A_BOLD)
-                stdscr.addstr(y + 3, x + 2, "[Y] Yes       [N] Cancel", curses.A_REVERSE)
-                stdscr.refresh()
-            except curses.error:
-                pass
+            return
+        y = (h - box_h) // 2
+        x = (w - box_w) // 2
+        BORDER = curses.color_pair(accent_color) | curses.A_DIM
+        TITLE = curses.color_pair(accent_color) | curses.A_BOLD
+        BODY = 0  # plain text (not dim) so the body is legible inside the card
+        DIM = curses.A_DIM
+        try:
+            # Top border with title-tab: ╭─[ Title ]─╮ style — subtle flag that
+            # this is a distinct card, not a raw reverse-video slab.
+            stdscr.addstr(y, x, "╭" + "─" * (box_w - 2) + "╮", BORDER)
+            # Fill interior with opaque spaces (occludes whatever was below).
+            for i in range(1, box_h - 1):
+                stdscr.addstr(y + i, x, "│", BORDER)
+                stdscr.addstr(y + i, x + 1, " " * (box_w - 2))
+                stdscr.addstr(y + i, x + box_w - 1, "│", BORDER)
+            stdscr.addstr(y + box_h - 1, x, "╰" + "─" * (box_w - 2) + "╯", BORDER)
+
+            # Title row: bold, indented 3 cols. Truncate with … if needed.
+            title_max = box_w - 6
+            tline = title if len(title) <= title_max else title[: title_max - 1] + "…"
+            stdscr.addstr(y + 1, x + 3, tline, TITLE)
+
+            # Body rows start after title + blank line
+            row = y + 3
+            for ln in body_lines:
+                stdscr.addstr(row, x + 3, ln[: box_w - 6], BODY)
+                row += 1
+
+            # Horizontal rule separating body from action bar (hairline, dimmed)
+            rule_y = y + box_h - 3
+            stdscr.addstr(rule_y, x + 3, "─" * (box_w - 6), BORDER)
+
+            # Action bar: primary left (accent) with ↵ keycap, secondary right
+            # (dim) with Esc keycap. The keycaps ensure the user always knows
+            # the keyboard shortcuts.
+            action_y = y + box_h - 2
+            bar_left = f"❯ {p_label}"
+            left_hint = " · ↵"
+            right_hint = "Esc · "
+            bar_right = f"{right_hint}{s_label}"
+            # Layout: " {bar_left}{left_hint}  …  {bar_right} "
+            left_total = len(bar_left) + len(left_hint)
+            right_total = len(bar_right)
+            inner_w = box_w - 6  # 3-col padding each side
+            pad = max(2, inner_w - left_total - right_total)
+            # Primary action
+            stdscr.addstr(action_y, x + 3, bar_left, TITLE)
+            stdscr.addstr(action_y, x + 3 + len(bar_left), left_hint, DIM)
+            # Secondary action
+            right_x = x + 3 + left_total + pad
+            stdscr.addstr(action_y, right_x, bar_right, DIM)
+
+            stdscr.refresh()
+        except curses.error:
+            pass
+
+    while True:
+        render()
         k = stdscr.getch()
         if k == curses.KEY_RESIZE:
             stdscr.erase()
-            continue  # redraw on next loop iteration
-        if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
+            continue
+        # Primary keys + Enter default
+        if k in p_keys or k in (10, 13, curses.KEY_ENTER):
             curses.flushinp()
             return True
-        if k in (ord("n"), ord("N"), 27):
+        # Secondary keys + Esc default
+        if k in s_keys or k == 27:
             curses.flushinp()
             return False
+
+
+def _confirm_skip(stdscr):
+    """Ask the user to confirm they want to start the session with no
+    SkillNote collection loaded. Returns True on confirm, False on cancel."""
+    return _draw_modal(
+        stdscr,
+        title="Skip SkillNote for this session?",
+        body=[
+            "Claude Code will start with no SkillNote skills loaded.",
+            "",
+            "You can run /skillnote anytime to pick or create a collection later.",
+        ],
+        primary=("Yes, skip", (ord("y"), ord("Y"))),
+        secondary=("Cancel", (ord("n"), ord("N"))),
+    )
 
 
 def _create_collection(name):
@@ -130,41 +251,21 @@ def _create_collection(name):
 
 
 def _confirm_activate_existing(stdscr, name, count):
-    """Inline Y/N prompt when Create hits a 409. Returns True to activate."""
-    import curses
-    curses.flushinp()
-    h, w = stdscr.getmaxyx()
-    box_h, box_w = 5, min(w - 4, 60)
-    if h < box_h + 2 or w < box_w + 2:
-        try:
-            stdscr.addstr(max(0, h - 1), 0, f" '{name}' exists. Activate? [y/N] "[:w - 1], curses.A_REVERSE)
-            stdscr.clrtoeol()
-            stdscr.refresh()
-        except curses.error:
-            pass
-    else:
-        y = (h - box_h) // 2
-        x = (w - box_w) // 2
-        try:
-            for i in range(box_h):
-                stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
-            msg = f'"{name}" already exists with {count} skill(s).'
-            stdscr.addstr(y + 1, x + 2, msg[:box_w - 4], curses.A_REVERSE | curses.A_BOLD)
-            stdscr.addstr(y + 3, x + 2, "Activate it? [Y] Yes  [N] No", curses.A_REVERSE)
-            stdscr.refresh()
-        except curses.error:
-            pass
-    while True:
-        k = stdscr.getch()
-        if k == curses.KEY_RESIZE:
-            stdscr.erase()
-            return _confirm_activate_existing(stdscr, name, count)  # re-render
-        if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
-            curses.flushinp()
-            return True
-        if k in (ord("n"), ord("N"), 27):
-            curses.flushinp()
-            return False
+    """Inline confirm dialog when Create hits a 409 collision. Returns True
+    to activate the existing collection, False to return to the picker."""
+    skill_word = "skill" if count == 1 else "skills"
+    return _draw_modal(
+        stdscr,
+        title=f"“{name}” already exists",
+        body=[
+            f"A collection named “{name}” is already on this server "
+            f"with {count} {skill_word}.",
+            "",
+            "Activate it for this project?",
+        ],
+        primary=("Yes, activate", (ord("y"), ord("Y"))),
+        secondary=("Cancel", (ord("n"), ord("N"))),
+    )
 
 
 # Constants (from Claude Code's FuzzyPicker study)
@@ -345,6 +446,12 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
         curses.init_pair(5, 208, -1)
     except Exception:
         curses.init_pair(5, curses.COLOR_RED, -1)
+    # curses.wrapper() enables keypad on stdscr by default, but re-assert it
+    # for robustness against stripped-down terminals or third-party harnesses.
+    try:
+        stdscr.keypad(True)
+    except Exception:
+        pass
 
     curses.flushinp()
     stdscr.nodelay(True)
@@ -428,9 +535,11 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
 
         # If we're showing a create row, prepend a synthetic entry to filtered.
         # Use orig_idx = -1 to mark it as synthetic; the list-row renderer and
-        # enter-handler special-case this sentinel.
+        # enter-handler special-case this sentinel. We use the sparkle glyph
+        # ✦ rather than a "+" so the create action reads as a positive creation
+        # event rather than an addition operator.
         if create_slug is not None:
-            synthetic_label = f"+ Create '{create_slug}'"
+            synthetic_label = f"✦ Create '{create_slug}'"
             if recommended_kind == "create" and not search:
                 synthetic_label += " (Recommended)"
             synthetic = (-1, -1, (synthetic_label, 0, []))
@@ -515,19 +624,32 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
             hline_full(row); row += 1
 
             # ═══ SEPARATOR with stats ═══
-            stats = f" ● {total_skills} skills · {len(items)} collections "
+            # The stats bar uses the top rail of the body border as its
+            # anchor. We reserve space for " <N skills · M collections> "
+            # and then fill the rest with the rail (─). The numbers are drawn
+            # in accent to give the otherwise-dim rail a point of attention.
+            n_skills = f"{total_skills}"
+            n_cols = f"{len(items)}"
+            stats_plain = f" {n_skills} skills · {n_cols} collections "
             if compact:
-                # Compact: no center divider, so stats spans the full inner width.
+                # Compact: no center divider, stats spans the full inner width.
                 inner_w = bw - 2
-                sep = "├" + (stats + "─" * max(0, inner_w - len(stats)))[:inner_w] + "┤"
+                sep = "├" + (stats_plain + "─" * max(0, inner_w - len(stats_plain)))[:inner_w] + "┤"
             else:
                 left_inner = left_w - 1
-                left_part = "├" + (stats + "─" * max(0, left_inner - len(stats)))[:left_inner]
+                left_part = "├" + (stats_plain + "─" * max(0, left_inner - len(stats_plain)))[:left_inner]
                 right_part = "┬" + "─" * max(0, right_w - 1) + "┤"
                 sep = left_part + right_part
             s(row, bx, sep[:bw], BORDER)
-            s(row, bx + 2, "●", GREEN)
-            s(row, bx + 4, f"{total_skills} skills · {len(items)} collections", DIM)
+            # Overdraw the stats tokens with accent/dim separation so the
+            # user's eye lands on the numbers first.
+            sx = bx + 2
+            s(row, sx, n_skills, ACCENT)
+            s(row, sx + len(n_skills) + 1, "skills", DIM)
+            s(row, sx + len(n_skills) + 1 + len("skills") + 1, "·", DIM)
+            sx2 = sx + len(n_skills) + 1 + len("skills") + 3
+            s(row, sx2, n_cols, ACCENT)
+            s(row, sx2 + len(n_cols) + 1, "collections", DIM)
             row += 1
 
             content_top = row
@@ -561,32 +683,58 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
             # Breathing space
             hline(row); row += 1
 
-            # List with Claude Code scroll indicators
+            # List with Claude Code scroll indicators.
+            # Reserve 2 trailing rows: one for the hairline rule, one for the
+            # pinned Skip entry. Without this reservation, a full list would
+            # push the rule+Skip off the bottom border on short terminals.
             list_top = row
-            list_h = h - row - footer_h - 1
+            list_h = h - row - footer_h - 1 - 2  # -2 for rule + skip
             visible_count = _clamp(list_h, MIN_VISIBLE, len(filtered) if filtered else MIN_VISIBLE)
 
             window_start = _clamp(cur - visible_count + 1, 0, max(0, len(filtered) - visible_count))
             visible = filtered[window_start:window_start + visible_count]
 
-            # Empty-state hint when a search yields no rows (and no Create offered)
+            # Empty-state hint when a search yields no rows (and no Create offered).
+            # The hint reads as an inline error rather than a list row: we prefix
+            # it with a dim "·" anchor and word-wrap to stay inside the pane.
             if not filtered and search:
                 hline(row)
                 # Diagnose why: either invalid slug, reserved word, or just no match.
                 qs = _slugify(search)
                 if not qs:
-                    hint = "No match. Type letters/digits to search."
+                    hint_text = "Type letters, digits, or hyphens to search."
+                    hint_title = "No matching input"
                 elif any(w in qs for w in RESERVED_WORDS):
-                    hint = "No match. Reserved word in name."
+                    hint_text = "“anthropic” and “claude” are reserved words."
+                    hint_title = "Invalid name"
                 elif len(qs) > _MAX_NAME:
-                    hint = f"No match. Names are limited to {_MAX_NAME} chars."
+                    hint_text = f"Names are limited to {_MAX_NAME} characters."
+                    hint_title = "Name too long"
                 else:
-                    hint = "No matching collection."
-                s(row, bx + 5, hint[: max(0, left_w - 6)], DIM)
+                    hint_text = "Try a different search term or press Esc."
+                    hint_title = "No matching collection"
+                # Title row (dim bold) + explanation row (dim plain)
+                s(row, bx + 3, "·", DIM)
+                s(row, bx + 5, hint_title[: max(0, left_w - 6)], DIM | BOLD)
                 row += 1
+                if row < h - footer_h - 3:
+                    hline(row)
+                    # Wrap the explanation within the left pane width.
+                    for ln in _wrap(hint_text, max(0, left_w - 8)):
+                        if row >= h - footer_h - 3:
+                            break
+                        hline(row)
+                        s(row, bx + 5, ln, DIM)
+                        row += 1
 
+            # When focus is on the right panel, the left cursor still indicates
+            # which row is "current" but uses a dimmed style so the eye follows
+            # the right panel. This gives Tab a visible state transition.
+            left_has_focus = (focus == "left")
+            cursor_attr = ACCENT if left_has_focus else DIM
             for vi, (sorted_idx, orig_idx, (name, count, skills)) in enumerate(visible):
-                if row >= h - footer_h - 1:
+                # Stop early so the hairline rule + pinned Skip row always fit.
+                if row >= h - footer_h - 3:
                     break
                 fi = window_start + vi
                 is_focused = (fi == cur)
@@ -603,7 +751,7 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
 
                 # Indicator (Claude Code ListItem pattern)
                 if is_focused:
-                    s(row, bx + 3, "❯", ACCENT)
+                    s(row, bx + 3, "❯", cursor_attr)
                 elif at_top:
                     s(row, bx + 3, "↑", DIM)
                 elif at_bot:
@@ -634,12 +782,14 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                     display_name = display_name[: max(0, name_budget - 1)] + "…"
 
                 if is_focused:
-                    s(row, nx, display_name, ACCENT)
+                    s(row, nx, display_name, cursor_attr)
                 else:
                     s(row, nx, display_name, DIM if not is_rec else 0)
                 if suffix:
-                    s(row, nx + len(display_name), suffix,
-                      DIM if not is_focused else ACCENT)
+                    if is_focused:
+                        s(row, nx + len(display_name), suffix, cursor_attr)
+                    else:
+                        s(row, nx + len(display_name), suffix, DIM)
 
                 # Count only for real collections. Synthetic Create rows have count=0
                 # which is meaningless and collides with a long label.
@@ -647,20 +797,44 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                     s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
                 row += 1
 
-            # Pad remaining left rows (reserve one row for the pinned Skip entry)
-            while row < h - footer_h - 2:
+            # Pad remaining left rows (reserve one row for the hairline divider
+            # above the pinned Skip entry, and one row for Skip itself).
+            while row < h - footer_h - 3:
                 hline(row)
                 row += 1
 
-            # Pinned Skip row — always visible
-            skip_is_focused = (focus == "left" and cur == len(filtered))  # one past last
+            # Hairline divider between the list and the pinned Skip — tells the
+            # eye that Skip is a distinct zone, not just the next list item.
+            # We draw a dashed rail inset 3 cols from the left border so it
+            # visually groups with the list content but reads as a rule.
             hline(row)
-            skip_label = "⊘ Skip (Ctrl+K)"
+            rail_w = max(0, left_w - 5)
+            s(row, bx + 3, "─" * rail_w, BORDER)
+            row += 1
+
+            # Pinned Skip row — always visible.
+            # The long label only renders when there's enough horizontal room;
+            # otherwise we fall back to the plain "Skip" label. Either way
+            # the row remains focusable and keyboard-discoverable.
+            skip_is_cur = (cur == len(filtered))
+            skip_is_focused = (focus == "left" and skip_is_cur)
+            hline(row)
+            skip_full = "⊘ Skip — start with no skills"
+            skip_plain = "⊘ Skip"
+            # Budget: left pane content from column bx+5 to bx+left_w-1 (or to
+            # the right border in compact mode). Keep a 2-col gutter from edge.
+            pane_end = (bx + left_w - 1) if not compact else (bx + bw - 2)
+            budget = max(0, pane_end - (bx + 5) - 2)
+            skip_label = skip_full if len(skip_full) <= budget else skip_plain
             if skip_is_focused:
-                s(row, bx + 3, "❯", ACCENT)
-                s(row, bx + 5, skip_label, ACCENT)
+                attr = ACCENT
+            elif skip_is_cur:  # focused-on-right case
+                attr = DIM
             else:
-                s(row, bx + 5, skip_label, DIM)
+                attr = DIM
+            if skip_is_cur:
+                s(row, bx + 3, "❯", ACCENT if skip_is_focused else DIM)
+            s(row, bx + 5, skip_label[: budget if budget > 0 else len(skip_label)], attr)
             row += 1
 
             # ═══ RIGHT PANEL: preview ═══
@@ -677,26 +851,29 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                 create_focused = sel_is_synthetic
 
                 if create_focused:
-                    # Header
-                    header = "Create new collection"
-                    s(rr, bx + left_w + 4, header, BOLD)
+                    # Extract slug from the synthetic label (between single quotes)
+                    create_name = sel_name.split("'")[1] if "'" in sel_name else ""
+                    # Mirror the real-collection header treatment: bold title on
+                    # the left, a small "new" badge on the right.
+                    s(rr, bx + left_w + 4, f"Create “{create_name}”", BOLD)
+                    badge = "new"
+                    s(rr, bx + bw - len(badge) - 2, badge, DIM)
                     rr += 1
                     s(rr, bx + left_w + 4, "─" * (right_w - 6), DIM)
                     rr += 1
                     rr += 1  # gap
-                    # Extract slug from the synthetic label (between single quotes)
-                    create_name = sel_name.split("'")[1] if "'" in sel_name else ""
                     for ln in _wrap(
-                        f"Press Enter to create '{create_name}' and activate it for this project.",
+                        f"Press Enter to create the “{create_name}” collection "
+                        "and activate it for this project.",
                         right_w - 8,
                     ):
                         if rr >= h - footer_h - 2:
                             break
-                        s(rr, bx + left_w + 4, ln, DIM)
+                        s(rr, bx + left_w + 4, ln, 0)  # plain text for readability
                         rr += 1
                     rr += 1
                     for ln in _wrap(
-                        "You can also type to search, or pick an existing collection from the list.",
+                        "Or type to search, or pick an existing collection from the list.",
                         right_w - 8,
                     ):
                         if rr >= h - footer_h - 2:
@@ -704,24 +881,28 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                         s(rr, bx + left_w + 4, ln, DIM)
                         rr += 1
                 elif skip_focused:
-                    # Skip row focused — explain the skip action.
-                    s(rr, bx + left_w + 4, "Skip", BOLD)
+                    # Skip row focused — explain what skipping does and how to
+                    # come back. We mirror the real-collection header treatment:
+                    # bold title on the left, a subtle keycap on the right.
+                    s(rr, bx + left_w + 4, "Skip SkillNote", BOLD)
+                    kc = "Ctrl+K"
+                    s(rr, bx + bw - len(kc) - 2, kc, DIM)
                     rr += 1
                     s(rr, bx + left_w + 4, "─" * (right_w - 6), DIM)
                     rr += 1
                     rr += 1  # gap
                     for ln in _wrap(
-                        "Start the session without any SkillNote collection active. "
-                        "Claude Code will see no skills from SkillNote.",
+                        "Start this session with no SkillNote skills loaded. "
+                        "Claude Code won't see any skills from SkillNote.",
                         right_w - 8,
                     ):
                         if rr >= h - footer_h - 2:
                             break
-                        s(rr, bx + left_w + 4, ln, DIM)
+                        s(rr, bx + left_w + 4, ln, 0)  # plain text for readability
                         rr += 1
                     rr += 1
                     for ln in _wrap(
-                        "You can run /skillnote anytime to switch collections later.",
+                        "You can run /skillnote anytime to pick a collection later.",
                         right_w - 8,
                     ):
                         if rr >= h - footer_h - 2:
@@ -801,33 +982,46 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                             s(rr, bx + left_w + 4, info, DIM)
                             s(rr, bx + bw - len(arrows) - 2, arrows, DIM)
 
-            # ═══ BOTTOM BORDER with hints + links ═══
+            # ═══ BOTTOM BORDER with hints + link ═══
+            # We right-align a single GitHub star link and left-align keyboard
+            # shortcuts that step down gracefully as the terminal narrows.
+            # The web URL is dropped from the footer (it's already reported by
+            # the post-selection confirmation line, and the footer is for
+            # shortcuts, not marketing).
             bot_row = h - 1
             s(bot_row, bx, "╰" + "─" * (bw - 2) + "╯", BORDER)
-            hints_full = " ↑/↓ navigate · ↵ select · Ctrl+K skip · Esc cancel "
-            hints_short = " ↑/↓ · ↵ select · Ctrl+K skip · Esc cancel "
+            hints_full = " ↑↓ move · ↵ select · Tab panes · Ctrl+K skip · Esc cancel "
+            hints_mid = " ↑↓ move · ↵ select · Ctrl+K skip · Esc cancel "
+            hints_short = " ↵ select · Ctrl+K skip · Esc cancel "
             hints_tiny = " ↵ select · Esc cancel "
-            links = f" {web_url} · {gh_url} ★ "
-            # Width budgeting: fit hints + at least one space + links without overlap.
-            # Skip links first if they won't fit even with the tiny hints; otherwise
-            # drop to progressively shorter hints.
+            link = f" ★ {gh_url} "
             inner = bw - 2  # space between the two border corners
             gap = 2
-            if len(hints_full) + gap + len(links) <= inner:
-                s(bot_row, bx + 2, hints_full, DIM)
-                s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
-            elif len(hints_short) + gap + len(links) <= inner:
-                s(bot_row, bx + 2, hints_short, DIM)
-                s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
-            elif len(hints_tiny) + gap + len(links) <= inner:
-                s(bot_row, bx + 2, hints_tiny, DIM)
-                s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
+
+            def _place(hint):
+                s(bot_row, bx + 2, hint, DIM)
+
+            def _place_link():
+                s(bot_row, bx + bw - len(link) - 1, link, DIM | curses.color_pair(1))
+
+            # Pick the largest hint that fits with the link; if none fit, drop
+            # the link and pick the largest hint that fits alone.
+            if len(hints_full) + gap + len(link) <= inner:
+                _place(hints_full); _place_link()
+            elif len(hints_mid) + gap + len(link) <= inner:
+                _place(hints_mid); _place_link()
+            elif len(hints_short) + gap + len(link) <= inner:
+                _place(hints_short); _place_link()
+            elif len(hints_tiny) + gap + len(link) <= inner:
+                _place(hints_tiny); _place_link()
             elif len(hints_full) + 2 <= inner:
-                s(bot_row, bx + 2, hints_full, DIM)
+                _place(hints_full)
+            elif len(hints_mid) + 2 <= inner:
+                _place(hints_mid)
             elif len(hints_short) + 2 <= inner:
-                s(bot_row, bx + 2, hints_short, DIM)
+                _place(hints_short)
             else:
-                s(bot_row, bx + 2, hints_tiny[: max(0, inner - 2)], DIM)
+                _place(hints_tiny[: max(0, inner - 2)])
 
         except curses.error:
             pass

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -369,6 +369,39 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
         stdscr.erase()
         h, w = stdscr.getmaxyx()
 
+        # ═══ TOO-SMALL GUARD ═══
+        # Below this size the layout degrades into garbage (clawd art alone is
+        # 9 cols wide, the branded header is ~24). Show a clean minimal message
+        # instead so the user isn't confused by half-drawn borders.
+        MIN_W = 40
+        MIN_H = 12
+        if w < MIN_W or h < MIN_H:
+            msg = "Terminal too small"
+            sub = f"Need at least {MIN_W}x{MIN_H} (got {w}x{h})"
+            hint = "Resize or press Esc"
+            try:
+                if h >= 3:
+                    y = max(0, h // 2 - 1)
+                    stdscr.addstr(y, max(0, (w - len(msg)) // 2), msg[: max(0, w - 1)],
+                                  curses.A_BOLD)
+                    if h >= 4:
+                        stdscr.addstr(y + 1, max(0, (w - len(sub)) // 2),
+                                      sub[: max(0, w - 1)], curses.A_DIM)
+                    if h >= 6:
+                        stdscr.addstr(y + 3, max(0, (w - len(hint)) // 2),
+                                      hint[: max(0, w - 1)], curses.A_DIM)
+                elif h >= 1:
+                    stdscr.addstr(0, 0, msg[: max(0, w - 1)])
+            except curses.error:
+                pass
+            stdscr.refresh()
+            key = stdscr.getch()
+            if key in (ord("q"), 27):
+                return None
+            if key == curses.KEY_RESIZE:
+                continue
+            continue
+
         # Filter
         if search:
             filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)
@@ -479,13 +512,15 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
 
             # ═══ SEPARATOR with stats ═══
             stats = f" ● {total_skills} skills · {len(items)} collections "
-            left_inner = left_w - 1
-            left_part = "├" + (stats + "─" * max(0, left_inner - len(stats)))[:left_inner]
             if compact:
-                right_part = "─" * (bw - left_w - 1) + "┤"
+                # Compact: no center divider, so stats spans the full inner width.
+                inner_w = bw - 2
+                sep = "├" + (stats + "─" * max(0, inner_w - len(stats)))[:inner_w] + "┤"
             else:
+                left_inner = left_w - 1
+                left_part = "├" + (stats + "─" * max(0, left_inner - len(stats)))[:left_inner]
                 right_part = "┬" + "─" * max(0, right_w - 1) + "┤"
-            sep = left_part + right_part
+                sep = left_part + right_part
             s(row, bx, sep[:bw], BORDER)
             s(row, bx + 2, "●", GREEN)
             s(row, bx + 4, f"{total_skills} skills · {len(items)} collections", DIM)
@@ -529,6 +564,22 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
 
             window_start = _clamp(cur - visible_count + 1, 0, max(0, len(filtered) - visible_count))
             visible = filtered[window_start:window_start + visible_count]
+
+            # Empty-state hint when a search yields no rows (and no Create offered)
+            if not filtered and search:
+                hline(row)
+                # Diagnose why: either invalid slug, reserved word, or just no match.
+                qs = _slugify(search)
+                if not qs:
+                    hint = "No match. Type letters/digits to search."
+                elif any(w in qs for w in RESERVED_WORDS):
+                    hint = "No match. Reserved word in name."
+                elif len(qs) > _MAX_NAME:
+                    hint = f"No match. Names are limited to {_MAX_NAME} chars."
+                else:
+                    hint = "No matching collection."
+                s(row, bx + 5, hint[: max(0, left_w - 6)], DIM)
+                row += 1
 
             for vi, (sorted_idx, orig_idx, (name, count, skills)) in enumerate(visible):
                 if row >= h - footer_h - 1:
@@ -609,78 +660,170 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
             row += 1
 
             # ═══ RIGHT PANEL: preview ═══
-            if not compact and sel_skills:
+            if not compact:
                 rr = content_top
 
                 # Empty line
                 rr += 1
 
-                # Header
-                header = sel_name
-                if sel_is_rec:
-                    header += " (Recommended)"
-                if focus == "right":
-                    s(rr, bx + left_w + 3, "❯ " + header, ACCENT)
-                else:
+                # Focused on the pinned Skip row — explain what Skip does.
+                skip_focused = (focus == "left" and filtered and cur == len(filtered)) or \
+                               (focus == "left" and not filtered)
+                # Focused on a synthetic Create row — explain what will happen.
+                create_focused = sel_is_synthetic
+
+                if create_focused:
+                    # Header
+                    header = "Create new collection"
                     s(rr, bx + left_w + 4, header, BOLD)
-                cnt_txt = f"{sel_count} skills"
-                s(rr, bx + bw - len(cnt_txt) - 2, cnt_txt, DIM)
-                rr += 1
-
-                # Separator
-                s(rr, bx + left_w + 4, "─" * (right_w - 6), DIM)
-                rr += 1
-
-                rr += 1  # gap
-
-                # Skill list with word-wrapped descriptions
-                desc_w = right_w - 8
-                skills_shown = 0
-                skill_list = sel_skills[right_scroll:]
-                for si, (slug, desc) in enumerate(skill_list):
-                    real_idx = si + right_scroll
-                    if rr >= h - footer_h - 2:
-                        break
-
-                    # Number + skill name
-                    num = f"{real_idx + 1}."
-                    s(rr, bx + left_w + 4, num, DIM)
-                    s(rr, bx + left_w + 4 + len(num) + 1, slug, curses.color_pair(1))
                     rr += 1
-                    skills_shown += 1
+                    s(rr, bx + left_w + 4, "─" * (right_w - 6), DIM)
+                    rr += 1
+                    rr += 1  # gap
+                    # Extract slug from the synthetic label (between single quotes)
+                    create_name = sel_name.split("'")[1] if "'" in sel_name else ""
+                    for ln in _wrap(
+                        f"Press Enter to create '{create_name}' and activate it for this project.",
+                        right_w - 8,
+                    ):
+                        if rr >= h - footer_h - 2:
+                            break
+                        s(rr, bx + left_w + 4, ln, DIM)
+                        rr += 1
+                    rr += 1
+                    for ln in _wrap(
+                        "You can also type to search, or pick an existing collection from the list.",
+                        right_w - 8,
+                    ):
+                        if rr >= h - footer_h - 2:
+                            break
+                        s(rr, bx + left_w + 4, ln, DIM)
+                        rr += 1
+                elif skip_focused:
+                    # Skip row focused — explain the skip action.
+                    s(rr, bx + left_w + 4, "Skip", BOLD)
+                    rr += 1
+                    s(rr, bx + left_w + 4, "─" * (right_w - 6), DIM)
+                    rr += 1
+                    rr += 1  # gap
+                    for ln in _wrap(
+                        "Start the session without any SkillNote collection active. "
+                        "Claude Code will see no skills from SkillNote.",
+                        right_w - 8,
+                    ):
+                        if rr >= h - footer_h - 2:
+                            break
+                        s(rr, bx + left_w + 4, ln, DIM)
+                        rr += 1
+                    rr += 1
+                    for ln in _wrap(
+                        "You can run /skillnote anytime to switch collections later.",
+                        right_w - 8,
+                    ):
+                        if rr >= h - footer_h - 2:
+                            break
+                        s(rr, bx + left_w + 4, ln, DIM)
+                        rr += 1
+                elif sel_name:
+                    # Real collection focus
+                    header = sel_name
+                    if sel_is_rec:
+                        header += " (Recommended)"
+                    if focus == "right":
+                        s(rr, bx + left_w + 3, "❯ " + header, ACCENT)
+                    else:
+                        s(rr, bx + left_w + 4, header, BOLD)
+                    cnt_txt = f"{sel_count} skills"
+                    s(rr, bx + bw - len(cnt_txt) - 2, cnt_txt, DIM)
+                    rr += 1
 
-                    # Description (stripped of triggers, word-wrapped)
-                    clean_desc = _strip_trigger(desc)
-                    if clean_desc and rr < h - footer_h - 2:
-                        for dl in _wrap(clean_desc, desc_w):
+                    # Separator
+                    s(rr, bx + left_w + 4, "─" * (right_w - 6), DIM)
+                    rr += 1
+
+                    rr += 1  # gap
+
+                    if not sel_skills:
+                        # Empty collection state
+                        for ln in _wrap(
+                            "No skills in this collection yet. "
+                            "Add skills from the web UI, then select this collection to use them.",
+                            right_w - 8,
+                        ):
                             if rr >= h - footer_h - 2:
                                 break
-                            s(rr, bx + left_w + 8, dl, DIM)
+                            s(rr, bx + left_w + 4, ln, DIM)
                             rr += 1
+                    else:
+                        # Skill list with word-wrapped descriptions
+                        desc_w = right_w - 8
+                        skills_shown = 0
+                        skill_list = sel_skills[right_scroll:]
+                        for si, (slug, desc) in enumerate(skill_list):
+                            real_idx = si + right_scroll
+                            if rr >= h - footer_h - 2:
+                                break
 
-                    # Gap between skills
-                    if rr < h - footer_h - 2:
-                        rr += 1
+                            # Number + skill name
+                            num = f"{real_idx + 1}."
+                            s(rr, bx + left_w + 4, num, DIM)
+                            s(rr, bx + left_w + 4 + len(num) + 1, slug or "(unnamed)",
+                              curses.color_pair(1))
+                            rr += 1
+                            skills_shown += 1
 
-                # Scroll info
-                last = right_scroll + skills_shown
-                if right_scroll > 0 or last < len(sel_skills):
-                    info = f"{right_scroll + 1}-{last} of {len(sel_skills)}"
-                    arrows = ""
-                    if right_scroll > 0:
-                        arrows += "↑ "
-                    if last < len(sel_skills):
-                        arrows += "↓"
-                    s(rr, bx + left_w + 4, info, DIM)
-                    s(rr, bx + bw - len(arrows) - 2, arrows, DIM)
+                            # Description (stripped of triggers, word-wrapped)
+                            clean_desc = _strip_trigger(desc)
+                            if clean_desc and rr < h - footer_h - 2:
+                                for dl in _wrap(clean_desc, desc_w):
+                                    if rr >= h - footer_h - 2:
+                                        break
+                                    s(rr, bx + left_w + 8, dl, DIM)
+                                    rr += 1
+
+                            # Gap between skills
+                            if rr < h - footer_h - 2:
+                                rr += 1
+
+                        # Scroll info
+                        last = right_scroll + skills_shown
+                        if right_scroll > 0 or last < len(sel_skills):
+                            info = f"{right_scroll + 1}-{last} of {len(sel_skills)}"
+                            arrows = ""
+                            if right_scroll > 0:
+                                arrows += "↑ "
+                            if last < len(sel_skills):
+                                arrows += "↓"
+                            s(rr, bx + left_w + 4, info, DIM)
+                            s(rr, bx + bw - len(arrows) - 2, arrows, DIM)
 
             # ═══ BOTTOM BORDER with hints + links ═══
             bot_row = h - 1
             s(bot_row, bx, "╰" + "─" * (bw - 2) + "╯", BORDER)
-            hints = " ↑/↓ navigate · ↵ select · Ctrl+K skip · Esc cancel "
-            s(bot_row, bx + 2, hints, DIM)
+            hints_full = " ↑/↓ navigate · ↵ select · Ctrl+K skip · Esc cancel "
+            hints_short = " ↑/↓ · ↵ select · Ctrl+K skip · Esc cancel "
+            hints_tiny = " ↵ select · Esc cancel "
             links = f" {web_url} · {gh_url} ★ "
-            s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
+            # Width budgeting: fit hints + at least one space + links without overlap.
+            # Skip links first if they won't fit even with the tiny hints; otherwise
+            # drop to progressively shorter hints.
+            inner = bw - 2  # space between the two border corners
+            gap = 2
+            if len(hints_full) + gap + len(links) <= inner:
+                s(bot_row, bx + 2, hints_full, DIM)
+                s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
+            elif len(hints_short) + gap + len(links) <= inner:
+                s(bot_row, bx + 2, hints_short, DIM)
+                s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
+            elif len(hints_tiny) + gap + len(links) <= inner:
+                s(bot_row, bx + 2, hints_tiny, DIM)
+                s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
+            elif len(hints_full) + 2 <= inner:
+                s(bot_row, bx + 2, hints_full, DIM)
+            elif len(hints_short) + 2 <= inner:
+                s(bot_row, bx + 2, hints_short, DIM)
+            else:
+                s(bot_row, bx + 2, hints_tiny[: max(0, inner - 2)], DIM)
 
         except curses.error:
             pass

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -734,21 +734,72 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
 
 
 def pick_fallback(items, recommended=0, recommended_kind="pick", recommended_slug=None):
+    """Non-curses fallback — plain numbered input, parity with curses options."""
     print("\n ✦ S K I L L N O T E — Pick a collection\n")
-    order = [recommended] + [i for i in range(len(items)) if i != recommended]
+
+    # Optional Create-suggestion row for unmatched folder
+    offset = 0
+    if recommended_kind == "create" and recommended_slug:
+        print(f"  0. + Create '{recommended_slug}' (Recommended)")
+        offset = 1
+
+    if recommended_kind == "pick" and 0 <= recommended < len(items):
+        order = [recommended] + [i for i in range(len(items)) if i != recommended]
+    else:
+        order = list(range(len(items)))
+
     for pos, i in enumerate(order):
         name, count, skills = items[i]
-        rec = " ★" if i == recommended else ""
+        rec = " (Recommended)" if i == recommended and recommended_kind == "pick" else ""
         print(f"  {pos + 1}. {name} ({count} skills){rec}")
-        if skills:
-            print(f"     {', '.join(s for s, _ in skills[:5])}")
+
+    print(f"  C. Create new collection")
+    print(f"  S. Skip (use no collections)")
     print()
     try:
         reply = input("  > ").strip()
     except (EOFError, KeyboardInterrupt):
         return None
-    if reply.lower() == "q" or not reply:
+    if not reply or reply.lower() == "q":
         return None
+
+    if reply.lower() == "s":
+        try:
+            confirm = input("  Are you sure you want to skip? [Y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        return SKIP_SENTINEL if confirm in ("y", "yes") else None
+
+    if reply.lower() == "c":
+        try:
+            new_name = input("  New collection name: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            return None
+        if not _is_valid_slug(new_name):
+            print("  Invalid name. Use only lowercase letters, numbers, hyphens, underscores.")
+            return None
+        status, payload = _create_collection(new_name)
+        if status == "ok":
+            return [new_name]
+        if status == "exists":
+            try:
+                confirm = input(f'  "{new_name}" exists with {payload or 0} skill(s). Activate? [Y/N] ').strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                return None
+            return [new_name] if confirm in ("y", "yes") else None
+        print(f"  Create failed: {payload}")
+        return None
+
+    # "0" → create-suggestion (Recommended path)
+    if offset and reply == "0":
+        status, payload = _create_collection(recommended_slug)
+        if status == "ok":
+            return [recommended_slug]
+        if status == "exists":
+            return [recommended_slug]  # already exists — activate it
+        print(f"  Create failed: {payload}")
+        return None
+
     try:
         n = int(reply)
         if 1 <= n <= len(items):

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -101,6 +101,72 @@ def _confirm_skip(stdscr):
             return False
 
 
+def _create_collection(name):
+    """Returns ('ok', None) | ('exists', count) | ('error', msg)."""
+    import urllib.error
+    host = _get_host()
+    api = f"http://{host}:8082"
+    payload = json.dumps({"name": name, "description": ""}).encode()
+    req = urllib.request.Request(
+        f"{api}/v1/collections",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(req, timeout=3).read()
+        return ("ok", None)
+    except urllib.error.HTTPError as e:
+        if e.code == 409:
+            try:
+                data = json.loads(urllib.request.urlopen(
+                    f"{api}/v1/skills?collections={name}", timeout=3).read())
+                return ("exists", len(data))
+            except Exception:
+                return ("exists", 0)
+        return ("error", f"HTTP {e.code}")
+    except Exception as e:
+        return ("error", str(e))
+
+
+def _confirm_activate_existing(stdscr, name, count):
+    """Inline Y/N prompt when Create hits a 409. Returns True to activate."""
+    import curses
+    curses.flushinp()
+    h, w = stdscr.getmaxyx()
+    box_h, box_w = 5, min(w - 4, 60)
+    if h < box_h + 2 or w < box_w + 2:
+        try:
+            stdscr.addstr(max(0, h - 1), 0, f" '{name}' exists. Activate? [y/N] "[:w - 1], curses.A_REVERSE)
+            stdscr.clrtoeol()
+            stdscr.refresh()
+        except curses.error:
+            pass
+    else:
+        y = (h - box_h) // 2
+        x = (w - box_w) // 2
+        try:
+            for i in range(box_h):
+                stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
+            msg = f'"{name}" already exists with {count} skill(s).'
+            stdscr.addstr(y + 1, x + 2, msg[:box_w - 4], curses.A_REVERSE | curses.A_BOLD)
+            stdscr.addstr(y + 3, x + 2, "Activate it? [Y] Yes  [N] No", curses.A_REVERSE)
+            stdscr.refresh()
+        except curses.error:
+            pass
+    while True:
+        k = stdscr.getch()
+        if k == curses.KEY_RESIZE:
+            stdscr.erase()
+            return _confirm_activate_existing(stdscr, name, count)  # re-render
+        if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
+            curses.flushinp()
+            return True
+        if k in (ord("n"), ord("N"), 27):
+            curses.flushinp()
+            return False
+
+
 # Constants (from Claude Code's FuzzyPicker study)
 MIN_VISIBLE = 2
 DEFAULT_VISIBLE = 12
@@ -247,13 +313,16 @@ def _strip_trigger(desc):
     return desc
 
 
-def pick(stdscr, items, recommended=0):
-    # Sort: recommended first
+def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug=None):
+    # Sort: recommended first (only when recommendation kind is 'pick')
     sorted_items = []
-    if 0 <= recommended < len(items):
+    if recommended_kind == "pick" and 0 <= recommended < len(items):
         sorted_items.append((recommended, items[recommended]))
-    for i, it in enumerate(items):
-        if i != recommended:
+        for i, it in enumerate(items):
+            if i != recommended:
+                sorted_items.append((i, it))
+    else:
+        for i, it in enumerate(items):
             sorted_items.append((i, it))
 
     cur = 0
@@ -306,6 +375,29 @@ def pick(stdscr, items, recommended=0):
                         if search.lower() in it[0].lower()]
         else:
             filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)]
+
+        # Determine the create-slug for this frame:
+        #   - with a search query that yields no matches AND produces a valid slug → "+ Create '{slug}'"
+        #   - no query, and the startup recommendation is "create" → "+ Create '{folder_slug}' (Recommended)"
+        create_slug = None
+        if search:
+            qs = _slugify(search)
+            if qs and _is_valid_slug(qs) and not any(n == qs for n, _, _ in items):
+                if not filtered:
+                    create_slug = qs
+        else:
+            if recommended_kind == "create":
+                create_slug = recommended_slug
+
+        # If we're showing a create row, prepend a synthetic entry to filtered.
+        # Use orig_idx = -1 to mark it as synthetic; the list-row renderer and
+        # enter-handler special-case this sentinel.
+        if create_slug is not None:
+            synthetic_label = f"+ Create '{create_slug}'"
+            if recommended_kind == "create" and not search:
+                synthetic_label += " (Recommended)"
+            synthetic = (-1, -1, (synthetic_label, 0, []))
+            filtered = [synthetic] + filtered
         # Allow cur == len(filtered) so the pinned Skip row is focusable
         if filtered:
             cur = _clamp(cur, 0, len(filtered))
@@ -594,8 +686,35 @@ def pick(stdscr, items, recommended=0):
                 if _confirm_skip(stdscr):
                     return SKIP_SENTINEL
                 continue
-            if filtered:
-                _, orig_idx, _ = filtered[cur]
+            if filtered and cur < len(filtered):
+                _, orig_idx, (sel_label, _, _) = filtered[cur]
+                if orig_idx == -1:
+                    # Synthetic "+ Create 'X'" row
+                    # Extract slug between the single quotes
+                    if "'" in sel_label:
+                        new_name = sel_label.split("'")[1]
+                    else:
+                        new_name = ""
+                    if not new_name:
+                        continue
+                    status, payload = _create_collection(new_name)
+                    if status == "ok":
+                        return [new_name]
+                    if status == "exists":
+                        if _confirm_activate_existing(stdscr, new_name, payload or 0):
+                            return [new_name]
+                        continue
+                    # error case: show brief toast then continue
+                    try:
+                        h, w = stdscr.getmaxyx()
+                        stdscr.addstr(h - 2, 2,
+                                      f"Create failed: {payload}. Press any key."[:max(0, w - 4)],
+                                      curses.A_REVERSE)
+                        stdscr.refresh()
+                        stdscr.getch()
+                    except curses.error:
+                        pass
+                    continue
                 return [items[orig_idx][0]]
         elif key == 11:  # Ctrl+K
             if _confirm_skip(stdscr):
@@ -614,7 +733,7 @@ def pick(stdscr, items, recommended=0):
             focus = "left"
 
 
-def pick_fallback(items, recommended=0):
+def pick_fallback(items, recommended=0, recommended_kind="pick", recommended_slug=None):
     print("\n ✦ S K I L L N O T E — Pick a collection\n")
     order = [recommended] + [i for i in range(len(items)) if i != recommended]
     for pos, i in enumerate(order):
@@ -718,11 +837,18 @@ def main():
                 pass
         print(f"  ✦ SkillNote: {name} ({count} skills)")
         return
-    recommended = _get_recommended(collections)
-    if HAS_CURSES:
-        chosen = curses.wrapper(pick, collections, recommended)
+    folder_raw = os.path.basename(os.getcwd())
+    rec_kind, rec_payload = _resolve_recommendation(folder_raw, collections)
+    if rec_kind == "pick":
+        recommended_idx = rec_payload
+        recommended_slug = None
     else:
-        chosen = pick_fallback(collections, recommended)
+        recommended_idx = -1
+        recommended_slug = rec_payload if rec_kind == "create" else None
+    if HAS_CURSES:
+        chosen = curses.wrapper(pick, collections, recommended_idx, rec_kind, recommended_slug)
+    else:
+        chosen = pick_fallback(collections, recommended_idx, rec_kind, recommended_slug)
     if chosen is None:
         current = _get_current_collections()
         if current:

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -418,7 +418,8 @@ def pick(stdscr, items, recommended=0):
                 else:
                     s(row, nx, name, DIM if not is_rec else 0)
                 if is_rec:
-                    s(row, nx + len(name) + 1, "★", YELLOW | (0 if is_focused else DIM))
+                    rec_label = " (Recommended)"
+                    s(row, nx + len(name), rec_label, DIM if not is_focused else ACCENT)
 
                 cnt = str(count)
                 s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
@@ -439,7 +440,7 @@ def pick(stdscr, items, recommended=0):
                 # Header
                 header = sel_name
                 if sel_is_rec:
-                    header += " ★"
+                    header += " (Recommended)"
                 if focus == "right":
                     s(rr, bx + left_w + 3, "❯ " + header, ACCENT)
                 else:

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -27,6 +27,7 @@ CONFIG_PATH = os.path.join(PROJECT_DIR, ".skillnote.json")
 import re as _re
 
 RESERVED_WORDS = ("anthropic", "claude")
+SKIP_SENTINEL = "__SKIP__"
 _SLUG_PATTERN = _re.compile(r"^[a-z0-9_-]+$")
 _MAX_NAME = 128
 
@@ -65,20 +66,38 @@ def _resolve_recommendation(folder_raw, existing):
 def _confirm_skip(stdscr):
     """Draw a centered modal and return True if user confirms."""
     import curses
-    h, w = stdscr.getmaxyx()
+    curses.flushinp()  # discard any buffered type-ahead so Enter can't auto-confirm
     box_h, box_w = 5, 40
-    y = (h - box_h) // 2
-    x = (w - box_w) // 2
-    for i in range(box_h):
-        stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
-    stdscr.addstr(y + 1, x + 2, "Are you sure you want to skip?", curses.A_REVERSE | curses.A_BOLD)
-    stdscr.addstr(y + 3, x + 2, "[Y] Yes       [N] Cancel", curses.A_REVERSE)
-    stdscr.refresh()
     while True:
+        h, w = stdscr.getmaxyx()
+        if h < box_h + 2 or w < box_w + 2:
+            # Fallback: too small for a centered modal
+            try:
+                stdscr.addstr(max(0, h - 1), 0, " Skip? [y/N] ", curses.A_REVERSE)
+                stdscr.clrtoeol()
+                stdscr.refresh()
+            except curses.error:
+                pass
+        else:
+            y = (h - box_h) // 2
+            x = (w - box_w) // 2
+            try:
+                for i in range(box_h):
+                    stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
+                stdscr.addstr(y + 1, x + 2, "Are you sure you want to skip?", curses.A_REVERSE | curses.A_BOLD)
+                stdscr.addstr(y + 3, x + 2, "[Y] Yes       [N] Cancel", curses.A_REVERSE)
+                stdscr.refresh()
+            except curses.error:
+                pass
         k = stdscr.getch()
+        if k == curses.KEY_RESIZE:
+            stdscr.erase()
+            continue  # redraw on next loop iteration
         if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
+            curses.flushinp()
             return True
         if k in (ord("n"), ord("N"), 27):
+            curses.flushinp()
             return False
 
 
@@ -287,8 +306,12 @@ def pick(stdscr, items, recommended=0):
                         if search.lower() in it[0].lower()]
         else:
             filtered = [(si, oi, it) for si, (oi, it) in enumerate(sorted_items)]
+        # Allow cur == len(filtered) so the pinned Skip row is focusable
         if filtered:
-            cur = _clamp(cur, 0, len(filtered) - 1)
+            cur = _clamp(cur, 0, len(filtered))
+        else:
+            # With no filtered items, cur=0 lands on Skip (only focusable thing)
+            cur = 0
 
         # Layout
         pad = 2
@@ -305,7 +328,7 @@ def pick(stdscr, items, recommended=0):
         # Selected collection for preview
         sel_name, sel_count, sel_skills = "", 0, []
         sel_is_rec = False
-        if filtered:
+        if filtered and cur < len(filtered):
             _, orig_idx, (sel_name, sel_count, sel_skills) = filtered[cur]
             sel_is_rec = (orig_idx == recommended)
 
@@ -530,7 +553,7 @@ def pick(stdscr, items, recommended=0):
             # ═══ BOTTOM BORDER with hints + links ═══
             bot_row = h - 1
             s(bot_row, bx, "╰" + "─" * (bw - 2) + "╯", BORDER)
-            hints = " ↑/↓ navigate · Enter select · Tab panel · Esc cancel "
+            hints = " ↑/↓ navigate · ↵ select · Ctrl+K skip · Esc cancel "
             s(bot_row, bx + 2, hints, DIM)
             links = f" {web_url} · {gh_url} ★ "
             s(bot_row, bx + bw - len(links) - 1, links, DIM | curses.color_pair(1))
@@ -569,14 +592,14 @@ def pick(stdscr, items, recommended=0):
             if focus == "left" and cur == len(filtered):
                 # Skip row
                 if _confirm_skip(stdscr):
-                    return "__SKIP__"
+                    return SKIP_SENTINEL
                 continue
             if filtered:
                 _, orig_idx, _ = filtered[cur]
                 return [items[orig_idx][0]]
         elif key == 11:  # Ctrl+K
             if _confirm_skip(stdscr):
-                return "__SKIP__"
+                return SKIP_SENTINEL
         elif key in (ord("q"), 27):
             return None
         elif key in (curses.KEY_BACKSPACE, 127, 8):
@@ -706,7 +729,7 @@ def main():
             print(f"  ✦ SkillNote: {', '.join(current)} (active)")
         return
     current = _get_current_collections()
-    if chosen == "__SKIP__":
+    if chosen == SKIP_SENTINEL:
         try:
             with open(CONFIG_PATH, "w") as f:
                 json.dump({"collections": []}, f, indent=2)

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -24,6 +24,44 @@ except ImportError:
 PROJECT_DIR = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
 CONFIG_PATH = os.path.join(PROJECT_DIR, ".skillnote.json")
 
+import re as _re
+
+RESERVED_WORDS = ("anthropic", "claude")
+_SLUG_PATTERN = _re.compile(r"^[a-z0-9_-]+$")
+_MAX_NAME = 128
+
+
+def _slugify(name):
+    s = (name or "").lower()
+    s = _re.sub(r"[^a-z0-9_-]+", "-", s)
+    s = _re.sub(r"-+", "-", s)
+    s = s.strip("-")
+    return s[:_MAX_NAME]
+
+
+def _is_valid_slug(s):
+    if not s or len(s) > _MAX_NAME:
+        return False
+    if not _SLUG_PATTERN.match(s):
+        return False
+    if any(w in s for w in RESERVED_WORDS):
+        return False
+    return True
+
+
+def _resolve_recommendation(folder_raw, existing):
+    """Returns ('pick', idx) | ('create', slug) | ('none', None)."""
+    slug = _slugify(folder_raw)
+    if not slug:
+        return ("none", None)
+    for i, (name, _count, _skills) in enumerate(existing):
+        if name == slug:
+            return ("pick", i)
+    if not _is_valid_slug(slug):
+        return ("none", None)
+    return ("create", slug)
+
+
 # Constants (from Claude Code's FuzzyPicker study)
 MIN_VISIBLE = 2
 DEFAULT_VISIBLE = 12

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -820,7 +820,7 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
             skip_is_cur = (cur == len(filtered))
             skip_is_focused = (focus == "left" and skip_is_cur)
             hline(row)
-            skip_full = "⊘ Skip — start with no skills"
+            skip_full = "⊘ Skip · start with no skills"
             skip_plain = "⊘ Skip"
             skip_hotkey = "Ctrl+K"  # right-aligned keycap hint
             # Budget: left pane content from column bx+5 to bx+left_w-1 (or to
@@ -993,45 +993,51 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
                             s(rr, bx + left_w + 4, info, DIM)
                             s(rr, bx + bw - len(arrows) - 2, arrows, DIM)
 
-            # ═══ BOTTOM BORDER with hints + link ═══
-            # We right-align a single GitHub star link and left-align keyboard
-            # shortcuts that step down gracefully as the terminal narrows.
-            # The web URL is dropped from the footer (it's already reported by
-            # the post-selection confirmation line, and the footer is for
-            # shortcuts, not marketing).
+            # ═══ BOTTOM BORDER with hints + links ═══
+            # Left-align keyboard shortcuts; right-align web + github links.
+            # Both step down gracefully as the terminal narrows — we try the
+            # richest combo first, then progressively drop the web URL, then
+            # the GitHub link, then the longest hint variant.
             bot_row = h - 1
             s(bot_row, bx, "╰" + "─" * (bw - 2) + "╯", BORDER)
             hints_full = " ↑↓ move · ↵ select · Tab panes · Ctrl+K skip · Esc cancel "
             hints_mid = " ↑↓ move · ↵ select · Ctrl+K skip · Esc cancel "
             hints_short = " ↵ select · Ctrl+K skip · Esc cancel "
             hints_tiny = " ↵ select · Esc cancel "
-            link = f" ★ {gh_url} "
+            link_both = f" {web_url} · ★ {gh_url} "
+            link_gh = f" ★ {gh_url} "
+            link_web = f" {web_url} "
             inner = bw - 2  # space between the two border corners
             gap = 2
 
             def _place(hint):
                 s(bot_row, bx + 2, hint, DIM)
 
-            def _place_link():
-                s(bot_row, bx + bw - len(link) - 1, link, DIM | curses.color_pair(1))
+            def _place_link(link_text):
+                s(bot_row, bx + bw - len(link_text) - 1, link_text,
+                  DIM | curses.color_pair(1))
 
-            # Pick the largest hint that fits with the link; if none fit, drop
-            # the link and pick the largest hint that fits alone.
-            if len(hints_full) + gap + len(link) <= inner:
-                _place(hints_full); _place_link()
-            elif len(hints_mid) + gap + len(link) <= inner:
-                _place(hints_mid); _place_link()
-            elif len(hints_short) + gap + len(link) <= inner:
-                _place(hints_short); _place_link()
-            elif len(hints_tiny) + gap + len(link) <= inner:
-                _place(hints_tiny); _place_link()
-            elif len(hints_full) + 2 <= inner:
-                _place(hints_full)
-            elif len(hints_mid) + 2 <= inner:
-                _place(hints_mid)
-            elif len(hints_short) + 2 <= inner:
-                _place(hints_short)
-            else:
+            # Choose the biggest combo of hint + link that fits. Prefer
+            # keeping both links; fall back to GitHub-only, then web-only,
+            # then no link.
+            link_tiers = [link_both, link_gh, link_web, ""]
+            hint_tiers = [hints_full, hints_mid, hints_short, hints_tiny]
+
+            placed = False
+            for link in link_tiers:
+                for hint in hint_tiers:
+                    # If no link, skip the link arithmetic
+                    needed = len(hint) + (gap + len(link) if link else 0)
+                    if needed <= inner:
+                        _place(hint)
+                        if link:
+                            _place_link(link)
+                        placed = True
+                        break
+                if placed:
+                    break
+            if not placed:
+                # Extremely narrow — truncate tiny hint to fit.
                 _place(hints_tiny[: max(0, inner - 2)])
 
         except curses.error:

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -62,6 +62,26 @@ def _resolve_recommendation(folder_raw, existing):
     return ("create", slug)
 
 
+def _confirm_skip(stdscr):
+    """Draw a centered modal and return True if user confirms."""
+    import curses
+    h, w = stdscr.getmaxyx()
+    box_h, box_w = 5, 40
+    y = (h - box_h) // 2
+    x = (w - box_w) // 2
+    for i in range(box_h):
+        stdscr.addstr(y + i, x, " " * box_w, curses.A_REVERSE)
+    stdscr.addstr(y + 1, x + 2, "Are you sure you want to skip?", curses.A_REVERSE | curses.A_BOLD)
+    stdscr.addstr(y + 3, x + 2, "[Y] Yes       [N] Cancel", curses.A_REVERSE)
+    stdscr.refresh()
+    while True:
+        k = stdscr.getch()
+        if k in (ord("y"), ord("Y"), 10, 13, curses.KEY_ENTER):
+            return True
+        if k in (ord("n"), ord("N"), 27):
+            return False
+
+
 # Constants (from Claude Code's FuzzyPicker study)
 MIN_VISIBLE = 2
 DEFAULT_VISIBLE = 12
@@ -425,10 +445,21 @@ def pick(stdscr, items, recommended=0):
                 s(row, bx + left_w - len(cnt) - 2, cnt, DIM)
                 row += 1
 
-            # Pad remaining left rows
-            while row < h - footer_h - 1:
+            # Pad remaining left rows (reserve one row for the pinned Skip entry)
+            while row < h - footer_h - 2:
                 hline(row)
                 row += 1
+
+            # Pinned Skip row — always visible
+            skip_is_focused = (focus == "left" and cur == len(filtered))  # one past last
+            hline(row)
+            skip_label = "⊘ Skip (Ctrl+K)"
+            if skip_is_focused:
+                s(row, bx + 3, "❯", ACCENT)
+                s(row, bx + 5, skip_label, ACCENT)
+            else:
+                s(row, bx + 5, skip_label, DIM)
+            row += 1
 
             # ═══ RIGHT PANEL: preview ═══
             if not compact and sel_skills:
@@ -523,7 +554,8 @@ def pick(stdscr, items, recommended=0):
                     right_scroll -= 1
         elif key == curses.KEY_DOWN:
             if focus == "left":
-                if filtered and cur < len(filtered) - 1:
+                # Allow navigating onto the pinned Skip row (index == len(filtered))
+                if cur < len(filtered):
                     cur += 1
                     right_scroll = 0
             else:
@@ -534,9 +566,17 @@ def pick(stdscr, items, recommended=0):
         elif key == curses.KEY_RIGHT:
             focus = "right"
         elif key in (ord("\n"), curses.KEY_ENTER, 10, 13):
+            if focus == "left" and cur == len(filtered):
+                # Skip row
+                if _confirm_skip(stdscr):
+                    return "__SKIP__"
+                continue
             if filtered:
                 _, orig_idx, _ = filtered[cur]
                 return [items[orig_idx][0]]
+        elif key == 11:  # Ctrl+K
+            if _confirm_skip(stdscr):
+                return "__SKIP__"
         elif key in (ord("q"), 27):
             return None
         elif key in (curses.KEY_BACKSPACE, 127, 8):
@@ -660,12 +700,23 @@ def main():
         chosen = curses.wrapper(pick, collections, recommended)
     else:
         chosen = pick_fallback(collections, recommended)
-    if not chosen:
+    if chosen is None:
         current = _get_current_collections()
         if current:
             print(f"  ✦ SkillNote: {', '.join(current)} (active)")
         return
     current = _get_current_collections()
+    if chosen == "__SKIP__":
+        try:
+            with open(CONFIG_PATH, "w") as f:
+                json.dump({"collections": []}, f, indent=2)
+                f.write("\n")
+        except PermissionError:
+            print("  ✦ SkillNote: cannot write .skillnote.json (permission denied)", file=sys.stderr)
+            return
+        _clean_skills_dir()
+        print("  ✦ SkillNote: no collection active (skipped)")
+        return
     changed = current != chosen
     try:
         with open(CONFIG_PATH, "w") as f:

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -198,23 +198,27 @@ def _get_host():
 
 
 def fetch_collections():
+    """Returns (host, cols) on success — cols may be `[]` if API returned an empty list.
+    Returns (host, None) when the API itself was unreachable or errored.
+    Main() uses this to distinguish 'server returned no collections yet' from
+    'can't talk to server'."""
     host = _get_host()
     api = f"http://{host}:8082"
     try:
         data = json.loads(urllib.request.urlopen(f"{api}/v1/collections", timeout=3).read())
-        cols = []
-        for c in data:
-            skills = []
-            try:
-                sd = json.loads(urllib.request.urlopen(
-                    f"{api}/v1/skills?collections={c['name']}", timeout=3).read())
-                skills = [(s["slug"], s.get("description", "")) for s in sd]
-            except Exception:
-                pass
-            cols.append((c["name"], c["count"], skills))
-        return host, cols
     except Exception:
-        return host, []
+        return host, None
+    cols = []
+    for c in data:
+        skills = []
+        try:
+            sd = json.loads(urllib.request.urlopen(
+                f"{api}/v1/skills?collections={c['name']}", timeout=3).read())
+            skills = [(s["slug"], s.get("description", "")) for s in sd]
+        except Exception:
+            pass
+        cols.append((c["name"], c["count"], skills))
+    return host, cols
 
 
 def _get_recommended(items):
@@ -1048,8 +1052,10 @@ def main():
     if not os.isatty(0) or not os.isatty(1):
         return
     host, collections = fetch_collections()
-    if not collections:
+    if collections is None:
+        # API unreachable — distinguish from "API returned empty list"
         print(f"  ✦ SkillNote: could not reach API at http://{host}:8082", file=sys.stderr)
+        print(f"               start the server with ./install.sh or set SKILLNOTE_HOST", file=sys.stderr)
         return
     if len(collections) == 1:
         name, count, _ = collections[0]

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -273,7 +273,8 @@ MIN_VISIBLE = 2
 DEFAULT_VISIBLE = 12
 COMPACT_THRESHOLD = 70
 LEFT_MIN_W = 28
-LEFT_MAX_W = 44
+LEFT_MAX_W = 60  # wider cap so long Create labels and collection names don't
+                 # get needlessly truncated on large terminals
 
 
 def _get_host():
@@ -821,20 +822,30 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
             hline(row)
             skip_full = "⊘ Skip — start with no skills"
             skip_plain = "⊘ Skip"
+            skip_hotkey = "Ctrl+K"  # right-aligned keycap hint
             # Budget: left pane content from column bx+5 to bx+left_w-1 (or to
             # the right border in compact mode). Keep a 2-col gutter from edge.
             pane_end = (bx + left_w - 1) if not compact else (bx + bw - 2)
             budget = max(0, pane_end - (bx + 5) - 2)
-            skip_label = skip_full if len(skip_full) <= budget else skip_plain
+            # Reserve room for the hotkey hint ("Ctrl+K" + one space separator)
+            # so the label gracefully shortens instead of overlapping the hint.
+            hotkey_pad = len(skip_hotkey) + 2  # 1 space before + safety margin
+            label_budget = max(0, budget - hotkey_pad)
+            skip_label = skip_full if len(skip_full) <= label_budget else skip_plain
+            # If even the plain label plus hotkey doesn't fit, drop the hotkey
+            # from the row (the footer still advertises it).
+            show_hotkey = len(skip_plain) + hotkey_pad <= budget
             if skip_is_focused:
                 attr = ACCENT
-            elif skip_is_cur:  # focused-on-right case
-                attr = DIM
             else:
                 attr = DIM
             if skip_is_cur:
                 s(row, bx + 3, "❯", ACCENT if skip_is_focused else DIM)
-            s(row, bx + 5, skip_label[: budget if budget > 0 else len(skip_label)], attr)
+            s(row, bx + 5, skip_label[: label_budget if label_budget > 0 else len(skip_label)], attr)
+            if show_hotkey:
+                # Right-align the keycap against the pane edge (dim, so it's
+                # legible without competing with the primary label).
+                s(row, pane_end - len(skip_hotkey), skip_hotkey, DIM)
             row += 1
 
             # ═══ RIGHT PANEL: preview ═══

--- a/plugin/skills/collection/SKILL.md
+++ b/plugin/skills/collection/SKILL.md
@@ -23,10 +23,12 @@ You MUST call the AskUserQuestion tool. Do NOT print a table or ask a text quest
 Call AskUserQuestion with these EXACT parameters:
 - `header`: "SkillNote"
 - `question`: "Pick a collection for this project:"
-- Build `options` from the collections fetched in Step 1. Each option:
-  - `label`: the collection name (e.g. "Conventions")
-  - `description`: "{count} skills" (e.g. "4 skills")
-- If `.skillnote.json` exists, add "(current)" to that collection's label
+- Build `options` in this order:
+  1. **Recommended first:** if `basename(cwd)` (lowercase, non-alphanumeric replaced with `-`) matches an existing collection name, put that option first and append ` · Recommended` to its description. Example description: `"12 skills · Recommended"`.
+  2. All other existing collections, each with `label` = name, `description` = `"{count} skills"`.
+  3. **If `.skillnote.json` exists**, add "(current)" to the currently-active collection's label.
+  4. `{"label": "Create new collection…", "description": "type a name next"}`
+  5. `{"label": "Skip (use no collections)", "description": "no skills synced"}`
 
 Example AskUserQuestion call:
 ```json
@@ -34,25 +36,57 @@ Example AskUserQuestion call:
   "header": "SkillNote",
   "question": "Pick a collection for this project:",
   "options": [
-    {"label": "Conventions (current)", "description": "4 skills"},
-    {"label": "DevOps", "description": "2 skills"},
-    {"label": "Official", "description": "2 skills"}
+    {"label": "frontend (current)", "description": "12 skills · Recommended"},
+    {"label": "backend", "description": "8 skills"},
+    {"label": "devops", "description": "3 skills"},
+    {"label": "Create new collection…", "description": "type a name next"},
+    {"label": "Skip (use no collections)", "description": "no skills synced"}
   ]
 }
 ```
 
 ## Step 3: Apply selection
 
-After the user picks, write `.skillnote.json` and sync:
+Branch based on what the user picked:
+
+### 3a. Existing collection or "(current)" option
+Strip any ` (current)` suffix. Then run:
 
 ```bash
 echo '{"collections": ["<SELECTED_NAME>"]}' > .skillnote.json
 skillnote-sync --force 2>/dev/null || true
 ```
 
-Replace `<SELECTED_NAME>` with the actual collection name the user chose (without the "(current)" suffix).
+Tell the user: "Switched to {name}. Skills will refresh."
 
-Then tell the user: "Switched to {name}. Skills will refresh."
+### 3b. "Create new collection…"
+Ask the user for a name in a plain text turn:
+
+> What should the new collection be called? (lowercase letters, numbers, hyphens, underscores — example: `my-project`)
+
+Wait for their reply. Validate: name must match `^[a-z0-9_-]+$`, be 1–128 chars, and not contain `anthropic` or `claude`. If invalid, explain and re-prompt once.
+
+Create the collection:
+
+```bash
+curl -sf -X POST "http://${CLAUDE_PLUGIN_OPTION_HOST:-localhost}:8082/v1/collections" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "<NAME>", "description": ""}'
+```
+
+If curl returns a 409 conflict, the collection already exists — tell the user and offer to activate it instead (one-question AskUserQuestion: `Yes, activate / No, pick a different name`).
+
+On success, write the name to `.skillnote.json` and run sync the same way as 3a.
+
+### 3c. "Skip (use no collections)"
+Write an empty collections list:
+
+```bash
+echo '{"collections": []}' > .skillnote.json
+skillnote-sync --force 2>/dev/null || true
+```
+
+Tell the user: "Skipped. No skills will be synced to this project."
 
 ## Rules
 

--- a/plugin/skills/skill-push/SKILL.md
+++ b/plugin/skills/skill-push/SKILL.md
@@ -65,9 +65,11 @@ except Exception as e: print(f"Could not fetch: {e}")
 
 Every skill must belong to at least one collection. Use **AskUserQuestion** to let the user pick:
 - Show existing collections from the list above as options
-- Include an option to type a new collection name
+- Include an option to type a new collection name — names must match `^[a-z0-9_-]+$` (lowercase letters, numbers, hyphens, underscores), 1–128 chars, and cannot contain reserved words `anthropic` or `claude`
 - Recommend the collection that best fits the skill's domain
 - A skill cannot be pushed without a collection
+
+If the user types an invalid name, the POST /v1/skills call will return 422 `COLLECTION_NAME_INVALID`. Surface the error, explain the rule, and ask them to type a valid name before retrying.
 
 ## Step 5: Final Review
 

--- a/plugin/tests/test_skillnote_pick_helpers.py
+++ b/plugin/tests/test_skillnote_pick_helpers.py
@@ -1,0 +1,62 @@
+"""Unit tests for pure helpers in skillnote-pick."""
+import importlib.util
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "bin" / "skillnote-pick"
+    # skillnote-pick has no .py extension, so pass an explicit loader
+    loader = SourceFileLoader("skillnote_pick", str(path))
+    spec = importlib.util.spec_from_file_location("skillnote_pick", path, loader=loader)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_slugify_lowercases():
+    m = _load_module()
+    assert m._slugify("Frontend") == "frontend"
+
+
+def test_slugify_replaces_spaces():
+    m = _load_module()
+    assert m._slugify("My App") == "my-app"
+
+
+def test_slugify_collapses_and_strips():
+    m = _load_module()
+    assert m._slugify("  --My!!!App-- ") == "my-app"
+
+
+def test_slugify_returns_empty_for_all_invalid():
+    m = _load_module()
+    assert m._slugify("!!!") == ""
+
+
+def test_is_valid_slug():
+    m = _load_module()
+    assert m._is_valid_slug("frontend") is True
+    assert m._is_valid_slug("my-app_2") is True
+    assert m._is_valid_slug("My App") is False
+    assert m._is_valid_slug("") is False
+    assert m._is_valid_slug("claude-stuff") is False  # reserved word
+
+
+def test_resolve_recommendation_match():
+    m = _load_module()
+    existing = [("frontend", 5, []), ("backend", 3, [])]
+    assert m._resolve_recommendation("Frontend", existing) == ("pick", 0)
+
+
+def test_resolve_recommendation_create():
+    m = _load_module()
+    existing = [("frontend", 5, [])]
+    assert m._resolve_recommendation("My App", existing) == ("create", "my-app")
+
+
+def test_resolve_recommendation_none():
+    m = _load_module()
+    existing = [("frontend", 5, [])]
+    assert m._resolve_recommendation("!!!", existing) == ("none", None)

--- a/src/components/collections/CollectionPicker.tsx
+++ b/src/components/collections/CollectionPicker.tsx
@@ -3,6 +3,7 @@ import { useState, useMemo, useRef, useEffect } from 'react'
 import { Plus, X, FolderOpen, Check, Search } from 'lucide-react'
 import { getSkills } from '@/lib/skills-store'
 import { createCollectionApi, fetchCollectionsApi } from '@/lib/api/collections'
+import { isValidCollectionSlug } from '@/lib/collection-validation'
 
 type Props = {
   selected: string[]
@@ -87,6 +88,7 @@ export function CollectionPicker({ selected, onChange, placeholder, compact = fa
   const canCreate = useMemo(() => {
     const v = query.trim()
     if (!v) return false
+    if (!isValidCollectionSlug(v)) return false
     return !allCollections.some(c => c.toLowerCase() === v.toLowerCase()) &&
            !selected.some(c => c.toLowerCase() === v.toLowerCase())
   }, [query, allCollections, selected])

--- a/src/components/collections/CollectionPicker.tsx
+++ b/src/components/collections/CollectionPicker.tsx
@@ -1,8 +1,10 @@
 'use client'
 import { useState, useMemo, useRef, useEffect } from 'react'
 import { Plus, X, FolderOpen, Check, Search } from 'lucide-react'
+import { toast } from 'sonner'
 import { getSkills } from '@/lib/skills-store'
 import { createCollectionApi, fetchCollectionsApi } from '@/lib/api/collections'
+import { SkillNoteApiError } from '@/lib/api/client'
 import { isValidCollectionSlug } from '@/lib/collection-validation'
 
 type Props = {
@@ -99,21 +101,32 @@ export function CollectionPicker({ selected, onChange, placeholder, compact = fa
   async function add(item: string) {
     const name = item === '__create__' ? query.trim() : item
     if (!name) return
-    if (!selected.some(c => c.toLowerCase() === name.toLowerCase())) {
-      onChange([...selected, name])
-      if (item === '__create__') {
-        try {
-          await createCollectionApi(name, '')
-        } catch {
-          // Offline fallback: store locally
-          persistCollection(name)
-        }
-        try {
-          const fresh = await getAllCollectionsAsync()
-          setAllCollections(fresh)
-        } catch {}
-      }
+    if (selected.some(c => c.toLowerCase() === name.toLowerCase())) {
+      setOpen(false)
+      return
     }
+
+    if (item === '__create__') {
+      // Call API first — only add chip on success or offline fallback.
+      try {
+        await createCollectionApi(name, '')
+      } catch (err) {
+        if (err instanceof SkillNoteApiError && err.status >= 400 && err.status < 500) {
+          // Backend rejected — surface, don't add chip.
+          toast.error(err.message)
+          return  // keep dropdown open so user can fix the query
+        }
+        // Network / 5xx — persist locally so user doesn't lose work.
+        persistCollection(name)
+        toast.error(err instanceof Error ? err.message : 'Saved locally — server unreachable')
+      }
+      try {
+        const fresh = await getAllCollectionsAsync()
+        setAllCollections(fresh)
+      } catch {}
+    }
+
+    onChange([...selected, name])
     setOpen(false)
   }
 

--- a/src/components/collections/NewCollectionModal.tsx
+++ b/src/components/collections/NewCollectionModal.tsx
@@ -1,9 +1,10 @@
 'use client'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { FolderOpen, Plus, X, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { createCollectionApi } from '@/lib/api/collections'
+import { SkillNoteApiError } from '@/lib/api/client'
 import { validateCollectionName, COLLECTION_NAME_MAX } from '@/lib/collection-validation'
 
 type Props = { onClose: () => void; onCreated: (name: string, description: string) => void }
@@ -13,6 +14,8 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
   const [description, setDescription] = useState('')
   const [saving, setSaving] = useState(false)
   const [touched, setTouched] = useState(false)
+  const [apiError, setApiError] = useState<string | null>(null)
+  const nameRef = useRef<HTMLInputElement>(null)
 
   const nameErrors = touched ? validateCollectionName(name) : []
   const isValid = validateCollectionName(name).length === 0
@@ -35,7 +38,15 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
       try {
         await createCollectionApi(trimmedName, trimmedDesc)
       } catch (err) {
-        // Fallback: keep local-only entry so user doesn't lose their work if offline
+        // Distinguish 4xx (backend rejected — user should fix input) from
+        // network errors (server unreachable — offline fallback).
+        if (err instanceof SkillNoteApiError && err.status >= 400 && err.status < 500) {
+          // Backend rejected. Keep modal open, surface the error inline.
+          setApiError(err.message)
+          nameRef.current?.focus()
+          return
+        }
+        // Network / 5xx — treat as offline. Persist locally so work isn't lost.
         try {
           const meta = JSON.parse(localStorage.getItem('skillnote:collections-meta') || '{}')
           meta[trimmedName] = { description: trimmedDesc, created_at: new Date().toISOString() }
@@ -82,21 +93,22 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
               Name <span className="text-destructive">*</span>
             </label>
             <input
+              ref={nameRef}
               autoFocus
               value={name}
-              onChange={e => setName(e.target.value)}
+              onChange={e => { setName(e.target.value); if (apiError) setApiError(null) }}
               onBlur={() => setTouched(true)}
               onKeyDown={e => e.key === 'Enter' && handleCreate()}
               placeholder="e.g. Frontend, AI Tools, Utilities"
               maxLength={COLLECTION_NAME_MAX}
               className={`w-full h-9 px-3 text-[13px] bg-muted/60 border rounded-lg focus:outline-none focus:ring-1 placeholder:text-muted-foreground/50 transition-colors ${
-                nameErrors.length > 0 ? 'border-destructive focus:ring-destructive' : 'border-border/60 focus:ring-ring'
+                apiError || nameErrors.length > 0 ? 'border-destructive focus:ring-destructive' : 'border-border/60 focus:ring-ring'
               }`}
             />
-            {touched && nameErrors[0] && (
+            {(apiError || (touched && nameErrors[0])) && (
               <p className="mt-1 text-[11px] text-destructive flex items-center gap-1">
                 <AlertCircle className="h-3 w-3 shrink-0" />
-                {nameErrors[0].message}
+                {apiError || nameErrors[0]?.message}
               </p>
             )}
           </div>

--- a/src/components/collections/NewCollectionModal.tsx
+++ b/src/components/collections/NewCollectionModal.tsx
@@ -4,6 +4,7 @@ import { FolderOpen, Plus, X, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { createCollectionApi } from '@/lib/api/collections'
+import { validateCollectionName } from '@/lib/collection-validation'
 
 type Props = { onClose: () => void; onCreated: (name: string, description: string) => void }
 
@@ -22,7 +23,12 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
   }, [onClose])
 
   async function handleCreate() {
-    if (!name.trim()) { setNameError('Name is required'); nameRef.current?.focus(); return }
+    const errs = validateCollectionName(name)
+    if (errs.length > 0) {
+      setNameError(errs[0].message)
+      nameRef.current?.focus()
+      return
+    }
     setNameError('')
     setSaving(true)
     try {
@@ -81,7 +87,11 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
               ref={nameRef}
               autoFocus
               value={name}
-              onChange={e => { setName(e.target.value); if (nameError) setNameError('') }}
+              onChange={e => {
+                setName(e.target.value)
+                const errs = validateCollectionName(e.target.value)
+                setNameError(errs[0]?.message ?? '')
+              }}
               onKeyDown={e => e.key === 'Enter' && handleCreate()}
               placeholder="e.g. Frontend, AI Tools, Utilities"
               className={`w-full h-9 px-3 text-[13px] bg-muted/60 border rounded-lg focus:outline-none focus:ring-1 placeholder:text-muted-foreground/50 transition-colors ${
@@ -119,7 +129,7 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
           <Button
             size="sm"
             className="h-8 text-[13px] gap-1.5 bg-foreground text-background hover:bg-foreground/90"
-            disabled={!name.trim() || saving}
+            disabled={!name.trim() || saving || validateCollectionName(name).length > 0}
             onClick={handleCreate}
           >
             {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}

--- a/src/components/collections/NewCollectionModal.tsx
+++ b/src/components/collections/NewCollectionModal.tsx
@@ -1,10 +1,10 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { FolderOpen, Plus, X, Loader2, AlertCircle } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { createCollectionApi } from '@/lib/api/collections'
-import { validateCollectionName } from '@/lib/collection-validation'
+import { validateCollectionName, COLLECTION_NAME_MAX } from '@/lib/collection-validation'
 
 type Props = { onClose: () => void; onCreated: (name: string, description: string) => void }
 
@@ -12,8 +12,10 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [saving, setSaving] = useState(false)
-  const [nameError, setNameError] = useState('')
-  const nameRef = useRef<HTMLInputElement>(null)
+  const [touched, setTouched] = useState(false)
+
+  const nameErrors = touched ? validateCollectionName(name) : []
+  const isValid = validateCollectionName(name).length === 0
 
   // Escape to close
   useEffect(() => {
@@ -23,13 +25,9 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
   }, [onClose])
 
   async function handleCreate() {
+    setTouched(true)
     const errs = validateCollectionName(name)
-    if (errs.length > 0) {
-      setNameError(errs[0].message)
-      nameRef.current?.focus()
-      return
-    }
-    setNameError('')
+    if (errs.length > 0) return
     setSaving(true)
     try {
       const trimmedName = name.trim()
@@ -84,24 +82,21 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
               Name <span className="text-destructive">*</span>
             </label>
             <input
-              ref={nameRef}
               autoFocus
               value={name}
-              onChange={e => {
-                setName(e.target.value)
-                const errs = validateCollectionName(e.target.value)
-                setNameError(errs[0]?.message ?? '')
-              }}
+              onChange={e => setName(e.target.value)}
+              onBlur={() => setTouched(true)}
               onKeyDown={e => e.key === 'Enter' && handleCreate()}
               placeholder="e.g. Frontend, AI Tools, Utilities"
+              maxLength={COLLECTION_NAME_MAX}
               className={`w-full h-9 px-3 text-[13px] bg-muted/60 border rounded-lg focus:outline-none focus:ring-1 placeholder:text-muted-foreground/50 transition-colors ${
-                nameError ? 'border-destructive focus:ring-destructive' : 'border-border/60 focus:ring-ring'
+                nameErrors.length > 0 ? 'border-destructive focus:ring-destructive' : 'border-border/60 focus:ring-ring'
               }`}
             />
-            {nameError && (
+            {touched && nameErrors[0] && (
               <p className="mt-1 text-[11px] text-destructive flex items-center gap-1">
                 <AlertCircle className="h-3 w-3 shrink-0" />
-                {nameError}
+                {nameErrors[0].message}
               </p>
             )}
           </div>
@@ -129,7 +124,7 @@ export function NewCollectionModal({ onClose, onCreated }: Props) {
           <Button
             size="sm"
             className="h-8 text-[13px] gap-1.5 bg-foreground text-background hover:bg-foreground/90"
-            disabled={!name.trim() || saving || validateCollectionName(name).length > 0}
+            disabled={!name.trim() || saving || !isValid}
             onClick={handleCreate}
           >
             {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}

--- a/src/lib/collection-validation.ts
+++ b/src/lib/collection-validation.ts
@@ -1,0 +1,48 @@
+// src/lib/collection-validation.ts
+// Mirror of backend/app/validators/collection_validator.py
+
+export const COLLECTION_NAME_MAX = 128
+
+const NAME_PATTERN = /^[a-z0-9_-]+$/
+const RESERVED_WORDS = ['anthropic', 'claude']
+const XML_TAG_RE = /<\/?[a-zA-Z][^>]*>/
+
+export type ValidationError = { field: string; message: string }
+
+export function validateCollectionName(name: string): ValidationError[] {
+  const errors: ValidationError[] = []
+  if (!name || !name.trim()) {
+    errors.push({ field: 'name', message: 'Name is required' })
+    return errors
+  }
+  const stripped = name.trim()
+  if (stripped.length > COLLECTION_NAME_MAX) {
+    errors.push({ field: 'name', message: `Name must be ${COLLECTION_NAME_MAX} characters or fewer` })
+  }
+  if (!NAME_PATTERN.test(stripped)) {
+    errors.push({ field: 'name', message: 'Only lowercase letters, numbers, hyphens, and underscores allowed' })
+  }
+  for (const word of RESERVED_WORDS) {
+    if (stripped.includes(word)) {
+      errors.push({ field: 'name', message: `Name cannot contain reserved word "${word}"` })
+    }
+  }
+  if (XML_TAG_RE.test(stripped)) {
+    errors.push({ field: 'name', message: 'Name cannot contain XML tags' })
+  }
+  return errors
+}
+
+/** Slugify algorithm — shared with the slugify migration + picker's folder-suggestion. */
+export function slugifyCollectionName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')   // runs of invalid → single hyphen
+    .replace(/-+/g, '-')              // collapse consecutive hyphens
+    .replace(/^-|-$/g, '')            // strip leading/trailing hyphens
+    .slice(0, COLLECTION_NAME_MAX)
+}
+
+export function isValidCollectionSlug(s: string): boolean {
+  return validateCollectionName(s).length === 0
+}


### PR DESCRIPTION
## Summary

Adds Create / Skip / (Recommended) options to the terminal collection picker and tightens collection-name validation across the stack. Expanded scope during the session to include P0 quality fixes (error envelope, XSS vector on description, auto-promote implicit collections, UI error handling) and an extensive UX polish pass on the curses picker.

**Headline features:**
- Terminal picker (`plugin/bin/skillnote-pick`) now supports creating a new collection inline, skipping (start session with no skills), and a folder-name-based `(Recommended)` suggestion.
- Collection names locked to `^[a-z0-9_-]+$`, 1-128 chars, no reserved words (`anthropic`, `claude`).
- Alembic migration 0012 slugifies all existing collection names + rewrites skill references (two-pass, collision-safe).
- Slash-command `/skillnote:collection` gets parity Create/Skip/Recommended options.

**P0 quality fixes landed in-session:**
- Pydantic 422s now wrapped in standard `{"error":{"code","message"}}` envelope (fixes `[object Object]` toasts).
- Collection description rejects XML tags (closes stored-XSS vector).
- Skill-referenced collections auto-promote to explicit `collections` rows (fixes 404 on detail/PUT/DELETE for implicitly-created names).
- `NewCollectionModal` and inline `CollectionPicker` no longer swallow API errors or write ghost localStorage entries on 4xx — surface the real error, keep the modal open for retry.
- `install.sh` surfaces port conflicts and compose errors with guided recovery instead of silently exiting.

**Picker UX polish:**
- `(Recommended)` bracketed label replaces `★` marker (native Claude Code style).
- Pinned Skip row (always visible) with `Ctrl+K` hotkey and confirmation modal.
- Search-driven `+ Create 'X'` row with 409 activate-existing prompt.
- Rewrote modals as bordered cards with typography hierarchy (vs. reverse-video slabs).
- Graceful narrow-terminal degradation: truncation with `…`, tiered footer hints, too-small `Terminal too small` guard.
- Distinguishes API-unreachable from empty-DB; empty-DB now opens the picker so users can bootstrap their first collection from the terminal.

## Test plan

- [x] Backend unit tests pass (`pytest backend/tests/unit/` — 15+ new cases in `test_collection_validator.py` and `test_migration_0012_slugify_algorithm.py`)
- [x] Backend integration tests pass (`test_collections_api.py`, `test_skills_api.py`, new `test_validation_envelope.py`)
- [x] Plugin helper tests pass (`plugin/tests/test_skillnote_pick_helpers.py`, 8/8)
- [x] Playwright e2e pass (`e2e/collection-validation.spec.ts`, 7/7 — modal rejects uppercase/reserved/XML, accepts valid, 409 no ghost, network fallback, inline picker 409)
- [x] Migration 0012 runs cleanly on a fresh Docker seed + idempotent on re-run
- [x] `install.sh` end-to-end clean-stack boot verified
- [x] Picker visually verified via pyte VT100 emulator across 50+ scenarios (0/1/50/200 collections, folder match/no-match/invalid, search valid/invalid/reserved, 25/40/60/80/120/180-col widths, modals, focus states)

## Docs

- Design spec: `docs/superpowers/specs/2026-04-17-collection-picker-options-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-18-collection-picker-options.md`

## Touch points

40 commits spanning:
- `backend/app/validators/collection_validator.py` + `schemas/collection.py` + `main.py` + `api/skills.py`
- `backend/alembic/versions/0012_slugify_collection_names.py`
- `backend/scripts/seed_data.py` (lowercase slug alignment)
- `src/lib/collection-validation.ts`, `src/components/collections/NewCollectionModal.tsx`, `src/components/collections/CollectionPicker.tsx`
- `plugin/bin/skillnote-pick` (major rewrite of render/flow/modals)
- `plugin/skills/collection/SKILL.md`, `plugin/skills/skill-push/SKILL.md`
- `install.sh` (port-conflict guidance)
- Backend + e2e test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)