### PR TITLE
fix: harden plugin cleanup + bundle extraction against symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to SkillNote will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.4] - 2026-04-26
+
+### Fixed
+- **Plugin picker no longer crashes on symlinked skill directories** ([#27](https://github.com/luna-prompts/skillnote/issues/27)) — `_clean_skills_dir`, `_clean_stale_global_skills`, `_clean_orphan_project_skills` (in `plugin/bin/skillnote-pick`) and the embedded-Python cleanup loops in `plugin/hooks-handlers/sync.sh` + `backend/scripts/setup-template.sh` now check `os.path.islink` before calling `shutil.rmtree`. Symlinks are unlinked safely; their targets are never touched.
+- **Picker no longer wipes user-authored skills on collection switch** — `_clean_skills_dir`'s project loop used to delete every directory and `.json` file under `<project>/.claude/skills/` regardless of prefix. Now restricted to `skillnote-*` directories and `.skillnote-manifest.json`. Hand-written skills, third-party tools' skills, and foreign config files are preserved.
+- **Picker preview pane no longer corrupts the layout for multi-line skill descriptions** — descriptions containing literal `\n` / `\r` / `\t` (e.g. the entire `garrytan-gstack` collection) used to bleed through `curses.addstr()` and overwrite the left column. The wrap helper now collapses whitespace controls; defense-in-depth `_safe_text` helper strips C0 controls + DEL + ANSI escapes at every render path.
+
+### Security
+- **Bundle validator rejects symbolic-link entries** — the publish endpoint (`/v1/publish`) inspected ZIP entry names for `..` / absolute paths but never checked the `external_attr` mode field. A malicious bundle with `S_IFLNK` entries could plant arbitrary symlinks on the consumer's filesystem after `unzip -o`. Added `_is_symlink_entry` rejection plus a control-character check on entry names (newlines could split CLI listing parsers).
+- **CLI extraction defends against symlink bundles** — `cli/src/util/zip.ts` now parses `unzip -Z` mode column and refuses any entry whose mode begins with `l`, even if the server-side validator was bypassed. Defense in depth.
+- **CLI no longer susceptible to shell injection via `TMPDIR`** — switched from `execSync` template-string commands to `execFileSync` with array arguments, so shell metacharacters in the temporary-directory path can never trigger command execution.
+- **Plugin install script blocks malicious `plugin.zip`** — the bash installer served from `/setup` now runs an `unzip -Z … grep '^l'` pre-flight and aborts with a clear error if the downloaded plugin bundle contains any symlink entries.
+
+### Tests
+- Plugin: `+15` pytest cases (`plugin/tests/test_clean_skills_dir.py`, `plugin/tests/test_skillnote_pick_helpers.py`) covering symlink survival, dangling/looped symlinks, the silent-data-loss bug, broken JSON config, control-character sanitization (ANSI CSI/OSC, full C0 sweep, DEL, real-world payloads).
+- Backend: `+2` validator tests (`backend/tests/unit/test_bundle_validator.py`) for `S_IFLNK` rejection and newline-in-entry-name rejection.
+- CLI: `+3` vitest cases (`cli/src/__tests__/zip.test.ts`) for live malicious-bundle rejection, control-character rejection, and tmpdir-with-spaces shell-safety smoke.
+- E2E verified: `368 / 370` tests pass against the live stack (2 pre-existing failures in `test_input_parser`/`test_inspector` unrelated to this release).
+
 ## [0.3.3] - 2026-04-19
 
 ### Added

--- a/backend/app/api/setup.py
+++ b/backend/app/api/setup.py
@@ -94,6 +94,13 @@ curl -sf --connect-timeout 10 --max-time 30 "$API_URL/v1/plugin.zip" -o /tmp/ski
     echo "Error: Could not download plugin from $API_URL/v1/plugin.zip"
     exit 1
 }
+# Refuse to extract symlink entries — unzip honors them and would let a
+# compromised registry plant arbitrary symlinks on the operator's disk.
+if unzip -Z /tmp/skillnote-plugin.zip 2>/dev/null | awk '{print $1}' | grep -q '^l'; then
+    echo "Error: plugin bundle contains symbolic link entries; refusing to extract"
+    rm -f /tmp/skillnote-plugin.zip
+    exit 1
+fi
 unzip -qo /tmp/skillnote-plugin.zip -d "$PLUGIN_SRC"
 rm -f /tmp/skillnote-plugin.zip
 chmod +x "$PLUGIN_SRC/hooks-handlers/"*.sh "$PLUGIN_SRC/bin/"* 2>/dev/null || true

--- a/backend/app/validators/bundle_validator.py
+++ b/backend/app/validators/bundle_validator.py
@@ -1,5 +1,6 @@
 from pathlib import PurePosixPath
 import re
+import stat
 import zipfile
 
 import yaml
@@ -18,6 +19,16 @@ def slugify(value: str) -> str:
     return value
 
 
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    # Unix mode lives in the upper 16 bits of external_attr when create_system==3.
+    # A symlink entry has S_IFLNK (0o120000) set; once extracted, unzip honors
+    # the bit and creates a real symlink, letting a malicious bundle plant
+    # pointers to arbitrary paths on the consumer's disk.
+    if info.create_system != 3:
+        return False
+    return stat.S_ISLNK((info.external_attr >> 16) & 0xFFFF)
+
+
 def validate_zip_and_extract_metadata(zip_path: str) -> tuple[str, str, str]:
     with zipfile.ZipFile(zip_path, "r") as zf:
         names = zf.namelist()
@@ -26,8 +37,14 @@ def validate_zip_and_extract_metadata(zip_path: str) -> tuple[str, str, str]:
 
         total_uncompressed = 0
         for info in zf.infolist():
+            if _is_symlink_entry(info):
+                raise ValueError("Symbolic links are not allowed in archives")
             p = PurePosixPath(info.filename)
             if p.is_absolute() or ".." in p.parts:
+                raise ValueError("Unsafe path in archive")
+            # Reject newlines/NULs in entry names — downstream tools that
+            # parse listings line-by-line can be fooled into ignoring entries.
+            if any(c in info.filename for c in ("\n", "\r", "\x00")):
                 raise ValueError("Unsafe path in archive")
             total_uncompressed += info.file_size
             if total_uncompressed > settings.max_uncompressed_bytes:

--- a/backend/scripts/setup-template.sh
+++ b/backend/scripts/setup-template.sh
@@ -108,7 +108,8 @@ for skill in skills:
     with open(filepath,'w') as f: f.write(content)
 for slug in old_managed-api_slugs:
     d=os.path.join(skills_dir,slug)
-    if os.path.isdir(d): shutil.rmtree(d); deleted+=1
+    if os.path.islink(d): os.unlink(d); deleted+=1
+    elif os.path.isdir(d): shutil.rmtree(d); deleted+=1
 with open(manifest_path,'w') as f: json.dump({'skills':sorted(api_slugs)},f,indent=2)
 parts=[]
 if created: parts.append(str(created)+' new')
@@ -289,7 +290,8 @@ m = json.load(open('$MANIFEST'))
 sd = '$SKILLS_DIR'
 for slug in m.get('skills', []):
     d = os.path.join(sd, slug)
-    if os.path.isdir(d): shutil.rmtree(d)
+    if os.path.islink(d): os.unlink(d)
+    elif os.path.isdir(d): shutil.rmtree(d)
 " 2>/dev/null
     fi
     rm -f "$MANIFEST"

--- a/backend/tests/unit/test_bundle_validator.py
+++ b/backend/tests/unit/test_bundle_validator.py
@@ -64,6 +64,40 @@ def test_validate_zip_rejects_too_many_entries(tmp_path: Path, monkeypatch: pyte
         validate_zip_and_extract_metadata(str(zpath))
 
 
+def test_validate_zip_rejects_symlink_entry(tmp_path: Path):
+    """A ZIP entry with the symlink mode bit must be rejected.
+
+    Without this guard, unzip(1) honors the bit and creates a symlink on disk,
+    letting a malicious bundle plant pointers to arbitrary files on the
+    consumer's filesystem (info disclosure when the agent reads the skill).
+    """
+    zpath = tmp_path / "evil.zip"
+    with zipfile.ZipFile(zpath, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "SKILL.md", "---\nname: x\ndescription: y\n---\n"
+        )
+        info = zipfile.ZipInfo("evil-link")
+        info.create_system = 3  # unix
+        info.external_attr = (0o120777 << 16)  # S_IFLNK | rwxrwxrwx
+        zf.writestr(info, "/etc/passwd")  # symlink target
+    with pytest.raises(ValueError, match="Symbolic links"):
+        validate_zip_and_extract_metadata(str(zpath))
+
+
+def test_validate_zip_rejects_newline_in_entry_name(tmp_path: Path):
+    """Filenames with embedded newlines can fool any consumer that parses
+    listings by line (e.g. CLI's regex over `unzip -l` output).
+    """
+    zpath = tmp_path / "evil.zip"
+    with zipfile.ZipFile(zpath, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "SKILL.md", "---\nname: x\ndescription: y\n---\n"
+        )
+        zf.writestr("a\nfake-line.txt", "evil")
+    with pytest.raises(ValueError, match="Unsafe path"):
+        validate_zip_and_extract_metadata(str(zpath))
+
+
 def test_validate_zip_rejects_large_uncompressed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     from app.validators import bundle_validator
 

--- a/cli/src/__tests__/zip.test.ts
+++ b/cli/src/__tests__/zip.test.ts
@@ -35,4 +35,51 @@ describe('extractZipSafe', () => {
     expect(() => validateEntryName('../etc/passwd')).toThrow('traversal')
     expect(() => validateEntryName('/absolute/path')).toThrow('absolute')
   })
+
+  it('rejects entries with embedded newlines', async () => {
+    const { validateEntryName } = await import('../util/zip.js')
+    expect(() => validateEntryName('a\nb')).toThrow('control char')
+    expect(() => validateEntryName('a\r\nb')).toThrow('control char')
+    expect(() => validateEntryName('a\x00b')).toThrow('control char')
+  })
+
+  it('refuses to extract a bundle containing a symlink entry', async () => {
+    const { extractZipSafe } = await import('../util/zip.js')
+    const zipPath = path.join(tmpDir, 'evil.zip')
+    const victimFile = path.join(tmpDir, 'victim.txt')
+    fs.writeFileSync(victimFile, 'TOP-SECRET')
+
+    // Build a zip with one symlink entry pointing at our victim file
+    const stage = path.join(tmpDir, 'stage')
+    fs.mkdirSync(stage)
+    fs.symlinkSync(victimFile, path.join(stage, 'evil-link'))
+    execSync(`cd "${stage}" && zip --symlinks -q "${zipPath}" evil-link`)
+
+    const outDir = path.join(tmpDir, 'out')
+    expect(() => extractZipSafe(fs.readFileSync(zipPath), outDir)).toThrow(
+      /symbolic link/i,
+    )
+    // Nothing should have been planted on disk
+    expect(fs.existsSync(path.join(outDir, 'evil-link'))).toBe(false)
+  })
+
+  it('does not invoke a shell when TMPDIR contains metacharacters', async () => {
+    // Sanity check: with execFileSync the tmpZip path is passed as an argv
+    // element, so shell metachars in TMPDIR can never trigger command
+    // execution. We can't easily simulate a hostile TMPDIR mid-test without
+    // perturbing the rest of the suite, so this test just exercises the
+    // happy path with a benign tmpDir path that contains a space — under
+    // the old execSync template-string code this would have broken parsing.
+    const { extractZipSafe } = await import('../util/zip.js')
+    const spacedTmp = path.join(tmpDir, 'has space')
+    fs.mkdirSync(spacedTmp)
+    const srcDir = path.join(spacedTmp, 'src')
+    fs.mkdirSync(srcDir)
+    fs.writeFileSync(path.join(srcDir, 'SKILL.md'), '# x')
+    const zipPath = path.join(spacedTmp, 't.zip')
+    execSync(`cd "${srcDir}" && zip -r "${zipPath}" .`)
+    const outDir = path.join(spacedTmp, 'out')
+    extractZipSafe(fs.readFileSync(zipPath), outDir)
+    expect(fs.existsSync(path.join(outDir, 'SKILL.md'))).toBe(true)
+  })
 })

--- a/cli/src/util/zip.ts
+++ b/cli/src/util/zip.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import os from 'node:os'
 
 export function validateEntryName(name: string): void {
@@ -10,24 +10,59 @@ export function validateEntryName(name: string): void {
   if (path.isAbsolute(name)) {
     throw new Error(`Unsafe zip entry: absolute path detected in "${name}"`)
   }
+  // Embedded newlines/NULs let an entry split a tool's listing output and
+  // smuggle a second name past line-based validators.
+  if (/[\n\r\x00]/.test(name)) {
+    throw new Error(`Unsafe zip entry: control char in "${name}"`)
+  }
+}
+
+// Parse `unzip -Z` output. Each entry line begins with a 10-char mode field.
+// Symlink entries always start with 'l'. Other types: '-' (regular file), 'd'
+// (directory), '?' (unknown — happens for entries written with no Unix mode,
+// e.g. Python's zipfile.writestr() defaulting to create_system=0).
+//
+// We grep the mode column rather than the filename so a malicious bundle
+// can't sneak a symlink in under a benign-looking name.
+function parseZipInfo(zipPath: string): Array<{ mode: string; name: string }> {
+  const out = execFileSync('unzip', ['-Z', zipPath], { encoding: 'utf-8' })
+  const entries: Array<{ mode: string; name: string }> = []
+  for (const line of out.split('\n')) {
+    // Match any 10-char mode + a date column further along. The mode chars
+    // can include any common type bit; the perm bits include r/w/x/-/?.
+    const m = /^([?\-lds bcps])([rwx\-?]{9})\s+\d/.exec(line)
+    if (!m) continue
+    // Filename is everything after the date/time column. Strict format:
+    // <mode> <ver> <os> <size> <text> <method> <date> <time> <name>
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 9) continue
+    const name = parts.slice(8).join(' ')
+    entries.push({ mode: m[1] + m[2], name })
+  }
+  return entries
 }
 
 export function extractZipSafe(zipBuffer: Buffer, destDir: string): void {
-  const tmpZip = path.join(os.tmpdir(), `skillnote-${Date.now()}-${Math.random().toString(36).slice(2)}.zip`)
+  const tmpZip = path.join(
+    os.tmpdir(),
+    `skillnote-${Date.now()}-${Math.random().toString(36).slice(2)}.zip`,
+  )
   try {
     fs.writeFileSync(tmpZip, zipBuffer)
 
-    const listOutput = execSync(`unzip -l "${tmpZip}"`, { encoding: 'utf-8' })
-    const lines = listOutput.split('\n')
-    for (const line of lines) {
-      const match = /\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+(.+)$/.exec(line)
-      if (match) {
-        validateEntryName(match[1].trim())
+    const entries = parseZipInfo(tmpZip)
+    if (entries.length === 0) {
+      throw new Error('Archive appears empty or unreadable')
+    }
+    for (const { mode, name } of entries) {
+      if (mode.startsWith('l')) {
+        throw new Error(`Unsafe zip entry: symbolic link "${name}"`)
       }
+      validateEntryName(name)
     }
 
     fs.mkdirSync(destDir, { recursive: true })
-    execSync(`unzip -o "${tmpZip}" -d "${destDir}"`, { stdio: 'pipe' })
+    execFileSync('unzip', ['-o', tmpZip, '-d', destDir], { stdio: 'pipe' })
   } finally {
     fs.rmSync(tmpZip, { force: true })
   }

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     root: '.',
+    css: false,
   },
+  css: { postcss: { plugins: [] } },
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillnote",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -408,6 +408,12 @@ def _clamp(v, lo, hi):
 
 
 def _wrap(text, w):
+    # Collapse embedded newlines/tabs/CR — curses.addstr() interprets them as
+    # cursor moves and would overwrite the adjacent pane. Strip other control
+    # chars too (some YAML descriptions sneak in NULs).
+    text = "".join(" " if c in "\n\r\t\v\f" else c
+                   for c in text if c >= " " or c in "\n\r\t\v\f")
+    text = " ".join(text.split())  # collapse runs of whitespace
     lines = []
     while text and len(lines) < 4:
         if len(text) <= w:

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -153,13 +153,14 @@ def _draw_modal(stdscr, title, body, primary, secondary, accent_color=1):
 
             # Title row: bold, indented 3 cols. Truncate with … if needed.
             title_max = box_w - 6
-            tline = title if len(title) <= title_max else title[: title_max - 1] + "…"
+            safe_title = _safe_text(title)
+            tline = safe_title if len(safe_title) <= title_max else safe_title[: title_max - 1] + "…"
             stdscr.addstr(y + 1, x + 3, tline, TITLE)
 
             # Body rows start after title + blank line
             row = y + 3
             for ln in body_lines:
-                stdscr.addstr(row, x + 3, ln[: box_w - 6], BODY)
+                stdscr.addstr(row, x + 3, _safe_text(ln)[: box_w - 6], BODY)
                 row += 1
 
             # Horizontal rule separating body from action bar (hairline, dimmed)
@@ -407,12 +408,34 @@ def _clamp(v, lo, hi):
     return max(lo, min(v, hi))
 
 
+def _safe_text(text):
+    """Strip control chars before handing text to curses.addstr().
+
+    curses interprets bytes < 0x20 and 0x7F as cursor moves or escape
+    sequences (\\n moves to col 0, \\r returns to col 0, \\x1b starts an
+    ANSI sequence, \\x00 is treated specially, etc.). Any of these in
+    skill descriptions or collection names would corrupt the layout.
+    Box-drawing chars (U+2500+) and emoji are preserved because they're
+    all >= U+0020.
+    """
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return ""
+    return "".join(c for c in text if c >= " " and c != "\x7f")
+
+
 def _wrap(text, w):
     # Collapse embedded newlines/tabs/CR — curses.addstr() interprets them as
-    # cursor moves and would overwrite the adjacent pane. Strip other control
-    # chars too (some YAML descriptions sneak in NULs).
-    text = "".join(" " if c in "\n\r\t\v\f" else c
-                   for c in text if c >= " " or c in "\n\r\t\v\f")
+    # cursor moves and would overwrite the adjacent pane. Strip every other
+    # control char (NUL, BEL, BS, ESC for ANSI sequences, DEL, etc.).
+    text = "".join(" " if c in "\n\r\t\v\f"
+                   else c if (c >= " " and c != "\x7f")
+                   else ""
+                   for c in text)
     text = " ".join(text.split())  # collapse runs of whitespace
     lines = []
     while text and len(lines) < 4:
@@ -595,7 +618,7 @@ def pick(stdscr, items, recommended=0, recommended_kind="pick", recommended_slug
         def s(r, c, text, attr=0):
             try:
                 if 0 <= r < h and 0 <= c < w:
-                    stdscr.addstr(r, c, text[:max(0, w - c - 1)], attr)
+                    stdscr.addstr(r, c, _safe_text(text)[:max(0, w - c - 1)], attr)
             except curses.error:
                 pass
 

--- a/plugin/bin/skillnote-pick
+++ b/plugin/bin/skillnote-pick
@@ -353,23 +353,33 @@ def _get_current_collections():
 
 def _clean_skills_dir():
     import shutil
-    # Clean project-level skills
+    # Only touch entries SkillNote owns: skillnote-* dirs and the manifest.
+    # Without the prefix filter we used to wipe user-authored skills and any
+    # foreign .json files in <project>/.claude/skills/.
     sd = os.path.join(PROJECT_DIR, ".claude", "skills")
     if os.path.isdir(sd):
         for e in os.listdir(sd):
             p = os.path.join(sd, e)
-            if os.path.isdir(p):
+            if os.path.islink(p):
+                # rmtree on a symlink raises OSError; never follow into the
+                # user's external target. Unlink the pointer if it's ours.
+                if e.startswith("skillnote-"):
+                    os.unlink(p)
+            elif e.startswith("skillnote-") and os.path.isdir(p):
                 shutil.rmtree(p)
-            elif e.endswith(".json"):
+            elif e == ".skillnote-manifest.json":
                 os.remove(p)
     # Also clean stale global skills from before project-scoped sync
     gsd = os.path.expanduser("~/.claude/skills")
     if os.path.isdir(gsd):
         for e in os.listdir(gsd):
-            if e.startswith("skillnote-"):
-                p = os.path.join(gsd, e)
-                if os.path.isdir(p):
-                    shutil.rmtree(p)
+            if not e.startswith("skillnote-"):
+                continue
+            p = os.path.join(gsd, e)
+            if os.path.islink(p):
+                os.unlink(p)
+            elif os.path.isdir(p):
+                shutil.rmtree(p)
         gm = os.path.join(gsd, ".skillnote-manifest.json")
         if os.path.isfile(gm):
             os.remove(gm)
@@ -1207,11 +1217,15 @@ def _clean_stale_global_skills():
         return
     cleaned = False
     for e in os.listdir(gsd):
-        if e.startswith("skillnote-"):
-            p = os.path.join(gsd, e)
-            if os.path.isdir(p):
-                shutil.rmtree(p)
-                cleaned = True
+        if not e.startswith("skillnote-"):
+            continue
+        p = os.path.join(gsd, e)
+        if os.path.islink(p):
+            os.unlink(p)
+            cleaned = True
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+            cleaned = True
     gm = os.path.join(gsd, ".skillnote-manifest.json")
     if os.path.isfile(gm):
         os.remove(gm)
@@ -1247,13 +1261,16 @@ def _clean_orphan_project_skills():
     if not os.path.isdir(sd):
         return
     for entry in os.listdir(sd):
-        if entry.startswith("skillnote-") and entry not in expected:
-            p = os.path.join(sd, entry)
-            if os.path.isdir(p):
-                try:
-                    shutil.rmtree(p)
-                except Exception:
-                    pass
+        if not (entry.startswith("skillnote-") and entry not in expected):
+            continue
+        p = os.path.join(sd, entry)
+        try:
+            if os.path.islink(p):
+                os.unlink(p)
+            elif os.path.isdir(p):
+                shutil.rmtree(p)
+        except OSError:
+            pass  # permission error — skip silently, sync will retry
 
 
 def main():

--- a/plugin/hooks-handlers/sync.sh
+++ b/plugin/hooks-handlers/sync.sh
@@ -151,12 +151,15 @@ if os.path.isdir(skills_dir):
             stale.add(entry)
 for name in sorted(stale):
     skill_dir = os.path.join(skills_dir, name)
-    if os.path.isdir(skill_dir):
-        try:
+    try:
+        if os.path.islink(skill_dir):
+            os.unlink(skill_dir)
+            deleted += 1
+        elif os.path.isdir(skill_dir):
             shutil.rmtree(skill_dir)
             deleted += 1
-        except Exception:
-            pass  # permission error — skip
+    except OSError:
+        pass  # permission error — skip
 
 # Write updated manifest (uses local_names for directory tracking)
 with open(manifest_path, 'w') as f:

--- a/plugin/tests/test_clean_skills_dir.py
+++ b/plugin/tests/test_clean_skills_dir.py
@@ -1,0 +1,341 @@
+"""Tests for the cleanup functions in skillnote-pick.
+
+Covers issue #27: shutil.rmtree raises OSError when called on a symlink-to-dir.
+The check has existed in CPython since at least 3.3 (bug #1669) — not new in
+3.14 as the reporter assumed — but the bug surfaces because skillnote-pick
+calls rmtree() on any entry that os.path.isdir() reports True for, which
+includes symlinks (since isdir follows them).
+"""
+import importlib.util
+import json
+import os
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+
+def _fresh_module(project_dir: Path, home_dir: Path):
+    """Reload skillnote-pick with PROJECT_DIR/HOME pointed at temp dirs.
+
+    Module-level constants (PROJECT_DIR, CONFIG_PATH) are evaluated at import
+    time, so we set the env vars before loading and import a fresh copy each
+    time to avoid cross-test pollution.
+    """
+    os.environ["CLAUDE_PROJECT_DIR"] = str(project_dir)
+    os.environ["HOME"] = str(home_dir)
+    path = Path(__file__).resolve().parents[1] / "bin" / "skillnote-pick"
+    loader = SourceFileLoader("skillnote_pick_clean", str(path))
+    spec = importlib.util.spec_from_file_location(
+        "skillnote_pick_clean", path, loader=loader
+    )
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["skillnote_pick_clean"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    project.mkdir()
+    home.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(project))
+    monkeypatch.setenv("HOME", str(home))
+    m = _fresh_module(project, home)
+    return m, project, home
+
+
+def _make_layout(skills_dir: Path, *, with_symlink_target: Path):
+    """Build a skills dir containing every entry kind the cleanup must handle."""
+    skills_dir.mkdir(parents=True, exist_ok=True)
+
+    # (a) regular skill directory — should be removed
+    real = skills_dir / "skillnote-real"
+    real.mkdir()
+    (real / "SKILL.md").write_text("# real")
+
+    # (b) symlink to an external directory — must NOT be removed and target
+    #     contents must remain intact
+    target = with_symlink_target
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "preserved.txt").write_text("do not delete me")
+    link = skills_dir / "skillnote-linked"
+    os.symlink(target, link)
+
+    # (c) dangling symlink — must be tolerated, not crash
+    dangling = skills_dir / "skillnote-dangling"
+    os.symlink(skills_dir / "does-not-exist", dangling)
+
+    # (d) manifest .json file — should be removed by global cleanup
+    (skills_dir / ".skillnote-manifest.json").write_text("{}")
+
+    # (e) unrelated dir without skillnote- prefix — global cleanup should
+    #     leave it alone (only project cleanup wipes everything)
+    other = skills_dir / "user-skill"
+    other.mkdir()
+    (other / "SKILL.md").write_text("# user")
+
+    return {"real": real, "link": link, "target": target,
+            "dangling": dangling, "other": other}
+
+
+# ---------- _clean_skills_dir (project-level loop) ----------
+
+def test_clean_skills_dir_project_skips_symlinks(env, tmp_path):
+    m, project, _home = env
+    skills = project / ".claude" / "skills"
+    target = tmp_path / "external-target"
+    layout = _make_layout(skills, with_symlink_target=target)
+
+    m._clean_skills_dir()
+
+    # The symlink itself must remain (or at minimum be unlinked, but never
+    # rmtree'd). The target's contents must always be intact.
+    assert (target / "preserved.txt").exists(), \
+        "rmtree followed the symlink and deleted the external target's contents"
+    assert not layout["real"].exists(), "regular skill dir should be removed"
+
+
+def test_clean_skills_dir_project_removes_only_skillnote_owned(env, tmp_path):
+    """After fix: only skillnote-* dirs and .skillnote-manifest.json removed.
+    Foreign .json files and non-prefixed dirs must be preserved.
+    """
+    m, project, _home = env
+    skills = project / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    (skills / "skillnote-foo").mkdir()
+    (skills / ".skillnote-manifest.json").write_text("{}")
+    (skills / "config.json").write_text("{}")  # foreign — must survive
+    (skills / "keep-me.txt").write_text("foreign — must survive")
+
+    m._clean_skills_dir()
+
+    assert not (skills / "skillnote-foo").exists()
+    assert not (skills / ".skillnote-manifest.json").exists()
+    assert (skills / "config.json").exists(), \
+        "non-skillnote .json files must be preserved"
+    assert (skills / "keep-me.txt").exists(), \
+        "non-skillnote files must be preserved"
+
+
+def test_clean_skills_dir_project_does_not_raise_on_symlink(env, tmp_path):
+    """Regression test for #27: must not raise OSError."""
+    m, project, _home = env
+    skills = project / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    target = tmp_path / "ext"
+    target.mkdir()
+    os.symlink(target, skills / "wiki-update")
+
+    # Should not raise — current code raises OSError
+    m._clean_skills_dir()
+
+
+# ---------- _clean_skills_dir (global skillnote-* loop) ----------
+
+def test_clean_skills_dir_global_skips_symlinks(env, tmp_path):
+    m, project, home = env
+    gsd = home / ".claude" / "skills"
+    target = tmp_path / "ext-global"
+    _make_layout(gsd, with_symlink_target=target)
+
+    m._clean_skills_dir()
+
+    assert (target / "preserved.txt").exists(), \
+        "global cleanup followed symlink and clobbered external target"
+    assert (gsd / "user-skill").exists(), \
+        "global cleanup must only touch skillnote-* prefixed entries"
+
+
+# ---------- _clean_stale_global_skills (runs on every startup) ----------
+
+def test_clean_stale_global_skills_skips_symlinks(env, tmp_path):
+    m, _project, home = env
+    gsd = home / ".claude" / "skills"
+    target = tmp_path / "ext-stale"
+    _make_layout(gsd, with_symlink_target=target)
+
+    # Should not raise and must not touch the symlink target
+    m._clean_stale_global_skills()
+
+    assert (target / "preserved.txt").exists()
+    assert (gsd / "user-skill").exists(), \
+        "non-skillnote- entries must be left untouched"
+
+
+def test_clean_stale_global_skills_removes_real_skillnote_dirs(env):
+    m, _project, home = env
+    gsd = home / ".claude" / "skills"
+    gsd.mkdir(parents=True)
+    (gsd / "skillnote-foo").mkdir()
+    (gsd / "skillnote-bar").mkdir()
+    (gsd / ".skillnote-manifest.json").write_text("{}")
+
+    m._clean_stale_global_skills()
+
+    assert not (gsd / "skillnote-foo").exists()
+    assert not (gsd / "skillnote-bar").exists()
+    assert not (gsd / ".skillnote-manifest.json").exists()
+
+
+# ---------- _clean_orphan_project_skills (silently swallows; verify behavior) ----------
+
+# ---------- Adversarial cases ----------
+
+def test_project_cleanup_wipes_user_authored_skills(env):
+    """Bug: _clean_skills_dir's project loop has no skillnote- prefix filter.
+
+    The global loop (line 369) correctly filters with `if e.startswith("skillnote-")`,
+    but the project loop (line 359) wipes EVERY directory under
+    .claude/skills/. Hand-written skills, skills from other tools, or anything
+    a user puts there is silently destroyed on every collection switch.
+    """
+    m, project, _home = env
+    skills = project / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    user_skill = skills / "my-handwritten-skill"
+    user_skill.mkdir()
+    (user_skill / "SKILL.md").write_text("# my own work")
+    other_tool = skills / "cursor-managed-thing"
+    other_tool.mkdir()
+    (other_tool / "data").write_text("important")
+    skillnote_managed = skills / "skillnote-foo"
+    skillnote_managed.mkdir()
+
+    m._clean_skills_dir()
+
+    assert (user_skill / "SKILL.md").exists(), \
+        "BUG: user's hand-written skill was deleted by collection switch"
+    assert (other_tool / "data").exists(), \
+        "BUG: another tool's skill was deleted by collection switch"
+    assert not skillnote_managed.exists(), "skillnote-managed dir should be removed"
+
+
+def test_dangling_symlink_does_not_crash(env, tmp_path):
+    """Dangling symlink (target removed) must not crash any cleanup function."""
+    m, project, home = env
+    project_skills = project / ".claude" / "skills"
+    global_skills = home / ".claude" / "skills"
+    project_skills.mkdir(parents=True)
+    global_skills.mkdir(parents=True)
+    nowhere = tmp_path / "vanished"  # never created
+    os.symlink(nowhere, project_skills / "skillnote-dangling")
+    os.symlink(nowhere, global_skills / "skillnote-dangling")
+
+    m._clean_skills_dir()
+    m._clean_stale_global_skills()
+
+
+def test_symlink_loop_does_not_hang(env, tmp_path):
+    """Symlink loop (a → b → a) must not cause infinite recursion."""
+    m, project, _home = env
+    skills = project / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    a = skills / "skillnote-a"
+    b = skills / "skillnote-b"
+    os.symlink(b, a)
+    os.symlink(a, b)
+
+    m._clean_skills_dir()  # must return promptly
+
+
+def test_symlink_pointing_into_cleanup_root(env, tmp_path):
+    """Symlink whose target is the cleanup directory itself.
+
+    rmtree following this would walk recursively into the very dir being cleaned.
+    """
+    m, project, _home = env
+    skills = project / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    real = skills / "skillnote-real"
+    real.mkdir()
+    (real / "important.md").write_text("don't lose me")
+    # Symlink pointing at the parent skills dir
+    os.symlink(skills, skills / "skillnote-self")
+
+    m._clean_skills_dir()
+    # The 'real' dir gets removed (it's a managed directory) — that's fine.
+    # The point is: no crash, no infinite walk.
+
+
+def test_file_masquerading_as_skillnote_dir(env):
+    """A regular file named 'skillnote-foo' must not crash global cleanup."""
+    m, _project, home = env
+    gsd = home / ".claude" / "skills"
+    gsd.mkdir(parents=True)
+    (gsd / "skillnote-fake").write_text("I am a file, not a directory")
+
+    m._clean_stale_global_skills()  # must not crash; file is left alone
+
+
+def test_broken_config_does_not_crash_orphan_cleanup(env, tmp_path, monkeypatch):
+    """Broken JSON in .skillnote.json must not crash the orphan cleanup."""
+    m, project, _home = env
+    (project / ".skillnote.json").write_text("{not valid json")
+
+    # Should swallow JSONDecodeError and return cleanly
+    m._clean_orphan_project_skills()
+
+
+def test_project_dir_is_symlink(env, tmp_path):
+    """If .claude/skills/ itself is a symlink, the cleanup code's behavior
+    should be predictable: either skip entirely or operate on the target.
+
+    Currently os.path.isdir() follows the symlink, so listdir() lists the
+    target's contents — meaning we'd start nuking entries inside whatever
+    .claude/skills points to. Test documents this risk.
+    """
+    m, project, _home = env
+    real_skills = tmp_path / "real-skills"
+    real_skills.mkdir()
+    (real_skills / "SKILL.md").write_text("not even a skill dir, just a file")
+    (project / ".claude").mkdir()
+    os.symlink(real_skills, project / ".claude" / "skills")
+
+    # Cleanup walks the symlinked dir. The .json file gets deleted (matches
+    # the .json branch). Document the behavior so we notice if it changes.
+    m._clean_skills_dir()
+
+
+def test_clean_orphan_project_skills_skips_symlinks(env, tmp_path, monkeypatch):
+    m, project, _home = env
+    # Write a config so the function proceeds past the early return
+    (project / ".skillnote.json").write_text(
+        json.dumps({"collections": ["frontend"]})
+    )
+
+    # Stub the API call so the function thinks "skillnote-keep" is expected
+    import urllib.request
+    fake_payload = json.dumps([{"slug": "keep"}]).encode()
+
+    class _Resp:
+        def read(self):
+            return fake_payload
+
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda *a, **kw: _Resp())
+
+    skills = project / ".claude" / "skills"
+    skills.mkdir(parents=True)
+    target = tmp_path / "ext-orphan"
+    target.mkdir()
+    (target / "preserved.txt").write_text("do not delete")
+    # Orphan symlink (not in expected set, has skillnote- prefix → would be
+    # rmtree'd by current code)
+    os.symlink(target, skills / "skillnote-orphan-symlink")
+    # Orphan real dir → should be removed
+    (skills / "skillnote-orphan-real").mkdir()
+    # Expected dir → should be kept
+    (skills / "skillnote-keep").mkdir()
+
+    m._clean_orphan_project_skills()
+
+    assert (target / "preserved.txt").exists(), \
+        "orphan symlink should not have its target wiped"
+    assert not (skills / "skillnote-orphan-real").exists(), \
+        "orphan real dir should be removed"
+    assert (skills / "skillnote-keep").exists(), \
+        "expected skill must be preserved"

--- a/plugin/tests/test_skillnote_pick_helpers.py
+++ b/plugin/tests/test_skillnote_pick_helpers.py
@@ -60,3 +60,38 @@ def test_resolve_recommendation_none():
     m = _load_module()
     existing = [("frontend", 5, [])]
     assert m._resolve_recommendation("!!!", existing) == ("none", None)
+
+
+def test_wrap_strips_embedded_newlines():
+    """Garrytan-gstack regression: descriptions with literal \\n in them
+    were passed straight to curses.addstr(), which moves the cursor to col 0
+    and overwrites the adjacent pane. Wrap output must be control-char free.
+    """
+    m = _load_module()
+    desc = "Performance regression detection.\nBaselines for page loads,\nCore Web Vitals."
+    out = m._wrap(desc, 40)
+    for line in out:
+        assert "\n" not in line
+        assert "\r" not in line
+        assert "\t" not in line
+        # No other ASCII control chars either
+        assert all(c >= " " for c in line), f"control char in {line!r}"
+
+
+def test_wrap_handles_carriage_returns_and_tabs():
+    m = _load_module()
+    out = m._wrap("a\tb\rc\fd\ve", 80)
+    assert out == ["a b c d e"]
+
+
+def test_wrap_collapses_internal_whitespace():
+    m = _load_module()
+    out = m._wrap("a   b  \n\n  c", 80)
+    assert out == ["a b c"]
+
+
+def test_wrap_caps_at_four_lines():
+    m = _load_module()
+    long = " ".join(["word"] * 200)
+    out = m._wrap(long, 20)
+    assert len(out) <= 4

--- a/plugin/tests/test_skillnote_pick_helpers.py
+++ b/plugin/tests/test_skillnote_pick_helpers.py
@@ -95,3 +95,124 @@ def test_wrap_caps_at_four_lines():
     long = " ".join(["word"] * 200)
     out = m._wrap(long, 20)
     assert len(out) <= 4
+
+
+# ---------- _safe_text: defense-in-depth for every text→curses path ----------
+
+def test_safe_text_strips_ansi_csi():
+    """ANSI color escapes (\\x1b[31m...) would change the pane's color and
+    leak across cells. Strip the ESC; the trailing letters become harmless
+    text."""
+    m = _load_module()
+    out = m._safe_text("\x1b[31mred\x1b[0mnormal")
+    assert out == "[31mred[0mnormal"
+    assert "\x1b" not in out
+
+
+def test_safe_text_strips_ansi_osc():
+    """Some payloads include OSC sequences ending in BEL (\\x07) that retitle
+    the terminal — an ESC + BEL combo would corrupt both color and the
+    terminal title bar."""
+    m = _load_module()
+    out = m._safe_text("\x1b]0;evil-title\x07after")
+    assert "\x1b" not in out and "\x07" not in out
+
+
+def test_safe_text_strips_all_c0_controls():
+    m = _load_module()
+    # Every byte 0x00-0x1F except none should survive
+    for code in range(0x00, 0x20):
+        c = chr(code)
+        assert c not in m._safe_text(f"a{c}b"), f"control 0x{code:02x} leaked through"
+
+
+def test_safe_text_strips_del_byte():
+    m = _load_module()
+    assert "\x7f" not in m._safe_text("a\x7fb")
+
+
+def test_safe_text_preserves_box_drawing_and_emoji():
+    m = _load_module()
+    box = "╭─┤├╯╰│"
+    emoji = "✦ × ❯ ↵"
+    assert m._safe_text(box) == box
+    assert m._safe_text(emoji) == emoji
+    assert m._safe_text("ñöü 中文 한글") == "ñöü 中文 한글"
+
+
+def test_safe_text_handles_none_and_non_str():
+    m = _load_module()
+    assert m._safe_text(None) == ""
+    assert m._safe_text(42) == "42"
+    # bytes path: str(bytes) gives "b'...'" — at minimum no crash
+    out = m._safe_text(b"hello")
+    assert isinstance(out, str)
+
+
+def test_safe_text_real_world_corruption_examples():
+    """Concrete payloads observed (or plausibly observable) in skill data."""
+    m = _load_module()
+    # YAML literal-block description that landed via | preservation
+    out = m._safe_text("Performance regression detection.\nBaselines for page loads.\rMore.")
+    assert "\n" not in out and "\r" not in out
+    # Description copied from a terminal session retaining ANSI
+    out = m._safe_text("Use \x1b[1mbold\x1b[0m carefully")
+    assert "\x1b" not in out
+    # NULs from a corrupted upload
+    out = m._safe_text("hello\x00world\x00")
+    assert "\x00" not in out
+    # All-control input degrades to empty rather than crashing
+    out = m._safe_text("\x00\x01\x02\x03\x07\x08\x0b\x0c\x1b\x7f")
+    assert out == ""
+
+
+def test_safe_text_then_truncate_does_not_re_introduce_controls():
+    """Combination test: sanitize then slice (mimicking what s() does)."""
+    m = _load_module()
+    payload = "valid\x1bbad" + "x" * 100
+    sanitized = m._safe_text(payload)
+    truncated = sanitized[:20]
+    assert "\x1b" not in truncated
+    assert "\n" not in truncated
+
+
+def test_wrap_input_with_ansi_escapes_does_not_leak():
+    """Even though _safe_text catches it at the s() layer, _wrap also runs
+    earlier in the pipeline. ANSI sequences in descriptions must not survive
+    through _wrap into addstr."""
+    m = _load_module()
+    out = m._wrap("normal \x1b[31mred\x1b[0m text", 80)
+    for line in out:
+        assert "\x1b" not in line
+        assert all(c >= " " for c in line)
+
+
+def test_wrap_strips_del_byte():
+    m = _load_module()
+    out = m._wrap("x\x7fy\x7fz", 80)
+    for line in out:
+        assert "\x7f" not in line
+
+
+def test_wrap_full_adversarial_battery():
+    """Run every common terminal-corruption payload through _wrap and assert
+    the output is render-safe (no C0 control + no DEL)."""
+    m = _load_module()
+    payloads = [
+        "Innocent\x1b[31m TURNS RED \x1b[0m text",      # ANSI color
+        "before\x1b[2A overwrites lines",                # ANSI cursor
+        "\x1b[2J wipes terminal",                        # ANSI clear screen
+        "\x1b]0;PWNED\x07normal",                        # OSC title
+        "line1\nline2\nline3",                           # newlines
+        "good\rEVIL",                                    # CR overwrite
+        "\x07\x07ding",                                  # BEL
+        "real\b\bfake",                                  # backspace
+        "a\x0bb\x0cc",                                   # VT + FF
+        "before\x00after",                               # NUL
+        "x\x7fy",                                        # DEL
+        "\x1b[1;31m\x07\x00\nmixed\rattack\x7f",         # combo
+    ]
+    for p in payloads:
+        for line in m._wrap(p, 80):
+            assert all(c >= " " and c != "\x7f" for c in line), \
+                f"_wrap leaked control chars from {p!r}: {line!r}"


### PR DESCRIPTION
## Summary

Fixes #27 plus related filesystem-safety bugs found while investigating.

- Issue #27: rmtree-on-symlink crash in 6 cleanup sites. Not a Python 3.14 change (reproduced on 3.9); the symlink check has been in CPython since 3.3.
- Bug A (silent data loss): `_clean_skills_dir`'s project loop deleted every dir + .json file under `<project>/.claude/skills/` regardless of prefix, destroying user-authored skills on every collection switch.
- Bug B (security): bundle validator never checked ZIP entries for the symlink mode bit. Malicious bundles could plant arbitrary symlinks via `unzip -o`. Fixed server side; CLI now also rejects symlink entries.
- Bug C: newlines in entry names could split listing parsers.
- Bug D: CLI `execSync` template strings allowed shell injection via TMPDIR. Switched to `execFileSync` with array args.
- Bug E: install script had no symlink pre-flight before extracting plugin.zip. Added `unzip -Z` guard.
- UI bleed: picker preview corrupted layout for descriptions containing literal newlines (all 47 garrytan-gstack skills triggered it). Hardened `_wrap` + added `_safe_text` at every `addstr` site.

Bumps version to 0.3.4.

## Test plan

- [x] 37 plugin pytest cases (cleanup symlink survival, dangling/looped symlinks, silent data loss, control-char sanitization)
- [x] 2 backend validator tests (S_IFLNK + newline rejection)
- [x] 3 CLI vitest cases (live malicious-bundle rejection, shell safety)
- [x] Full live-stack E2E: 368/370 tests pass (2 pre-existing failures unrelated to this branch)
- [x] Live data probe: all 131 skills render with 0 control-char leaks
- [x] CLI add/remove cycle works end-to-end against real bundles