### PR TITLE
ci(cli-smoke): drop macOS row — runners don't have Docker (fixes #46)

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -15,12 +15,11 @@ defaults:
 
 jobs:
   smoke-real-docker:
-    name: Real Docker smoke (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: Real Docker smoke (ubuntu-latest)
+    # macOS runners don't ship Docker, so we only run the real-Docker smoke on
+    # Linux. macOS coverage for everything that doesn't need a Docker daemon
+    # lives in cli-pr.yml's unit-test matrix.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- macOS GitHub runners don't ship Docker, so `cli-smoke.yml` failed on every master push at the `docker version` step
- Dropped `macos-latest` from the smoke matrix; the workflow is now a single Linux job
- `cli-pr.yml`'s unit-test matrix continues to cover macOS × node 20/22 for everything that doesn't need a Docker daemon

Fixes #46.

## Test plan

- [x] Workflow YAML still parses (matrix block removed cleanly)
- [ ] CI smoke job runs after merge — Ubuntu row should pass like it did before, no more red macOS row

🤖 Generated with [Claude Code](https://claude.com/claude-code)