### PR TITLE
fix(cli): skip port pre-check when our compose project is already up (fixes #41)

### DIFF
--- a/cli/src/commands/start.ts
+++ b/cli/src/commands/start.ts
@@ -8,7 +8,7 @@ import {
   ensureComposeExtracted,
 } from '../docker/compose.js'
 import { waitForHealthy } from '../docker/health.js'
-import { composeVersion, requireDocker } from '../docker/inspect.js'
+import { composeVersion, isProjectRunning, requireDocker } from '../docker/inspect.js'
 import { pkgInfo } from '../lib/package-info.js'
 import { checkPorts } from '../lib/ports.js'
 import { isInteractive } from '../lib/system.js'
@@ -95,20 +95,27 @@ export async function startCommand(opts: StartOptions = {}): Promise<void> {
       })
     }
 
-    const ports = await checkPorts([
-      { service: 'web', port: webPort },
-      { service: 'api', port: apiPort },
-    ])
-    const conflict = ports.find((p) => !p.free)
-    if (conflict) {
-      throw new UserFacingError({
-        header: `Port ${conflict.port} (${conflict.service}) is in use`,
-        body: 'Another process is already listening on that port.',
-        remediation: [
-          `Find it:    lsof -i :${conflict.port}`,
-          `Override:   skillnote start --${conflict.service}-port <free port>`,
-        ],
-      })
+    // If our own compose project is already up, the ports are bound by us —
+    // skip the host-port pre-check (which on macOS Docker Desktop sometimes
+    // misses gvproxy's IPv6 dual-stack binds) and let `compose up` be
+    // idempotent. See #41.
+    const alreadyUp = await isProjectRunning()
+    if (!alreadyUp) {
+      const ports = await checkPorts([
+        { service: 'web', port: webPort },
+        { service: 'api', port: apiPort },
+      ])
+      const conflict = ports.find((p) => !p.free)
+      if (conflict) {
+        throw new UserFacingError({
+          header: `Port ${conflict.port} (${conflict.service}) is in use`,
+          body: 'Another process is already listening on that port.',
+          remediation: [
+            `Find it:    lsof -i :${conflict.port}`,
+            `Override:   skillnote start --${conflict.service}-port <free port>`,
+          ],
+        })
+      }
     }
 
     prereq.stop(`Prerequisites ${c.ok('ok')}`)

--- a/cli/src/docker/inspect.ts
+++ b/cli/src/docker/inspect.ts
@@ -59,3 +59,36 @@ export async function composeVersion(): Promise<string | null> {
     return null
   }
 }
+
+/**
+ * Are there any running containers belonging to our compose project?
+ *
+ * Used to short-circuit the host-port pre-check on `skillnote start`: if
+ * SkillNote is already up, the ports are occupied *by us*, which a TCP probe
+ * can't reliably distinguish on macOS (Docker Desktop's gvproxy binds via
+ * IPv6 `::` and the dual-stack mapping isn't always visible to a plain IPv4
+ * probe — see #41). Asking Docker for the truth is more honest than guessing
+ * from the OS networking stack.
+ *
+ * Returns false on any docker error: the worst case is we fall through to
+ * the port check, which is the pre-existing behavior.
+ */
+export async function isProjectRunning(projectName = 'skillnote'): Promise<boolean> {
+  try {
+    const result = await execa(
+      'docker',
+      [
+        'ps',
+        '--filter',
+        `label=com.docker.compose.project=${projectName}`,
+        '--format',
+        '{{.Names}}',
+      ],
+      { reject: false, timeout: 5_000 },
+    )
+    if (result.exitCode !== 0) return false
+    return result.stdout.trim().length > 0
+  } catch {
+    return false
+  }
+}

--- a/cli/src/lib/ports.ts
+++ b/cli/src/lib/ports.ts
@@ -5,12 +5,13 @@ import getPort, { portNumbers } from 'get-port'
  *
  * Uses `get-port` (the same package the npm CLI and Cloudflare/Vercel
  * tooling rely on, ~17M weekly downloads). It probes every local network
- * interface from `os.networkInterfaces()` plus the IPv4 wildcard, so it
- * catches:
- *   - 127.0.0.1-only listeners
- *   - 0.0.0.0-bound listeners
- *   - IPv6 wildcard / Docker Desktop gvproxy dual-stack binds
- *   - listeners on any other configured interface (LAN IPs, etc.)
+ * interface from `os.networkInterfaces()` plus the IPv4 wildcard.
+ *
+ * Caveat (#41): macOS Docker Desktop's gvproxy binds via IPv6 `::` and
+ * dual-stacks to IPv4; that mapping isn't always visible to a pure
+ * userspace IPv4 probe. We work around this in the `start` command by
+ * short-circuiting the port check if our own compose project is already
+ * up (see `isProjectRunning` in `docker/inspect.ts`).
  *
  * Swallows `EADDRNOTAVAIL` / `EINVAL` (CI sandbox restrictions) so a
  * locked-down runner doesn't false-positive as "in use". `EACCES` is

--- a/cli/tests/unit/docker-inspect.test.ts
+++ b/cli/tests/unit/docker-inspect.test.ts
@@ -7,7 +7,7 @@ vi.mock('execa', () => ({
 }))
 
 import { execa } from 'execa'
-import { isDockerRunning, requireDocker } from '../../src/docker/inspect.js'
+import { isDockerRunning, isProjectRunning, requireDocker } from '../../src/docker/inspect.js'
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -74,5 +74,50 @@ describe('requireDocker', () => {
       expect(opts.remediation).toBeTruthy()
       expect(opts.docsUrl).toMatch(/docs\.docker\.com/)
     }
+  })
+})
+
+describe('isProjectRunning', () => {
+  it('returns true when docker ps lists at least one container for the project', async () => {
+    vi.mocked(execa).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: 'skillnote-api-1\nskillnote-web-1\nskillnote-postgres-1\n',
+      stderr: '',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock shape
+    } as any)
+    expect(await isProjectRunning()).toBe(true)
+  })
+
+  it('returns false when no containers match the project label', async () => {
+    vi.mocked(execa).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '\n',
+      stderr: '',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock shape
+    } as any)
+    expect(await isProjectRunning()).toBe(false)
+  })
+
+  it('returns false (does not throw) when docker errors', async () => {
+    vi.mocked(execa).mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Cannot connect to the Docker daemon',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock shape
+    } as any)
+    expect(await isProjectRunning()).toBe(false)
+  })
+
+  it('queries by compose project label', async () => {
+    vi.mocked(execa).mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock shape
+    } as any)
+    await isProjectRunning('custom-project')
+    const callArgs = vi.mocked(execa).mock.calls[0]
+    expect(callArgs[0]).toBe('docker')
+    expect(callArgs[1]).toContain('label=com.docker.compose.project=custom-project')
   })
 })


### PR DESCRIPTION
## Summary

- On macOS, Docker Desktop's gvproxy binds via IPv6 `::` and dual-stacks to IPv4. The pure-userspace IPv4 port probe (`get-port`) doesn't always see those binds, so the second `skillnote start` of a session would pass the port check, then fail at `docker compose up` with a confusing "port already allocated" error instead of a clean "Port 3000 in use" message.
- Sidesteps the dual-stack-detection question entirely: if any container labelled `com.docker.compose.project=skillnote` is already running, the ports are bound *by us* and compose up is idempotent — let it through.

## Changes

- `src/docker/inspect.ts`: new `isProjectRunning()` — calls `docker ps --filter label=...` and returns boolean.
- `src/commands/start.ts`: wrap the `checkPorts` block in `if (!alreadyUp)` so a second `start` is a graceful no-op resume.
- `src/lib/ports.ts`: updated header comment to honestly call out the gvproxy IPv6 limitation and point at the workaround.
- `tests/unit/docker-inspect.test.ts`: 4 new tests for `isProjectRunning` (running / empty / docker-error / label-arg).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (biome)
- [x] `npm run test` — 124 / 124 unit tests pass (including 9 in docker-inspect)
- [ ] Manual smoke on macOS: bring SkillNote up, then re-run `skillnote start` — should succeed, not error with "port 3000 in use"

Fixes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)