### PR TITLE
chore(brand): teal → emerald + quieter PWA install with persistent paths

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner'
 import { TopBar } from '@/components/layout/topbar'
 import { fetchSettings, updateSettings } from '@/lib/api/settings'
 import { OpenClawSetupCard } from '@/components/settings/openclaw-setup-card'
+import { PWAInstallButton } from '@/components/pwa-install-button'
 
 function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
   return (
@@ -161,6 +162,20 @@ export default function SettingsPage() {
           )}
 
           <OpenClawSetupCard />
+
+          {/* Desktop app */}
+          <section className="mb-10">
+            <h2 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-4">Desktop app</h2>
+            <div className="flex items-start justify-between gap-4 p-3.5 rounded-lg bg-muted/30 border border-border">
+              <div>
+                <p className="text-[14px] font-medium text-foreground">Install as a desktop app</p>
+                <p className="text-[13px] text-muted-foreground mt-0.5">
+                  Get a dock icon and chromeless window. Same data, no browser tab.
+                </p>
+              </div>
+              <PWAInstallButton variant="inline" className="shrink-0" />
+            </div>
+          </section>
 
           {/* About */}
           <section className="mb-10">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,12 +58,12 @@
   --secondary-foreground: #111318;
   --muted: #f0f0f2;
   --muted-foreground: #7a7a8a;
-  --accent: #0d9488;
+  --accent: #10b981;
   --accent-foreground: #ffffff;
   --destructive: #dc2626;
   --border: #e4e4e8;
   --input: #e4e4e8;
-  --ring: #0d9488;
+  --ring: #10b981;
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
@@ -76,7 +76,7 @@
   --sidebar-accent: #f0f0f2;
   --sidebar-accent-foreground: #111318;
   --sidebar-border: #e4e4e8;
-  --sidebar-ring: #0d9488;
+  --sidebar-ring: #10b981;
 }
 
 .dark {
@@ -92,12 +92,12 @@
   --secondary-foreground: #e8e8ed;
   --muted: #1e2029;
   --muted-foreground: #8b8b9e;
-  --accent: #0d9488;
+  --accent: #10b981;
   --accent-foreground: #ffffff;
   --destructive: #ef4444;
   --border: #252832;
   --input: #252832;
-  --ring: #0d9488;
+  --ring: #10b981;
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
@@ -110,7 +110,7 @@
   --sidebar-accent: #1e2029;
   --sidebar-accent-foreground: #e8e8ed;
   --sidebar-border: #252832;
-  --sidebar-ring: #0d9488;
+  --sidebar-ring: #10b981;
 }
 
 * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#0d9488",
+  themeColor: "#10b981",
 };
 
 export default function RootLayout({

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -10,7 +10,7 @@ export default function manifest(): MetadataRoute.Manifest {
     display: 'standalone',
     orientation: 'any',
     background_color: '#ffffff',
-    theme_color: '#0d9488',
+    theme_color: '#10b981',
     categories: ['developer', 'productivity', 'utilities'],
     icons: [
       // PNGs satisfy Chrome's install criteria (192 + 512 required).

--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -1,115 +1,50 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { Download, X } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { toast } from 'sonner'
+import { usePWAInstall } from '@/lib/use-pwa-install'
 
 /**
- * Minimal shape of the `beforeinstallprompt` event surfaced by Chromium-based
- * browsers. Not yet part of the standard TypeScript DOM lib, so we model it
- * locally rather than depending on `any`.
+ * Compact one-time install prompt. Shown only on first eligibility and
+ * only if not previously dismissed. Once dismissed, the user can still
+ * install from Settings → About or the sidebar footer pill.
  */
-interface BeforeInstallPromptEvent extends Event {
-  readonly platforms: string[]
-  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
-  prompt: () => Promise<void>
-}
-
-const DISMISS_KEY = 'skillnote:pwa-install-dismissed'
-
 export function PWAInstallPrompt() {
-  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null)
-  const [visible, setVisible] = useState(false)
+  const { canInstall, toastDismissed, install, dismissToast } = usePWAInstall()
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-
-    // Respect prior dismissal.
-    try {
-      if (window.localStorage.getItem(DISMISS_KEY) === '1') return
-    } catch {
-      // localStorage may be unavailable (private mode, SSR-ish edge cases).
-    }
-
-    const onBeforeInstallPrompt = (e: Event) => {
-      e.preventDefault()
-      setPromptEvent(e as BeforeInstallPromptEvent)
-      setVisible(true)
-    }
-
-    const onAppInstalled = () => {
-      setPromptEvent(null)
-      setVisible(false)
-    }
-
-    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
-    window.addEventListener('appinstalled', onAppInstalled)
-
-    return () => {
-      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
-      window.removeEventListener('appinstalled', onAppInstalled)
-    }
-  }, [])
+  if (!canInstall || toastDismissed) return null
 
   const handleInstall = async () => {
-    if (!promptEvent) return
-    await promptEvent.prompt()
-    const choice = await promptEvent.userChoice
-    if (choice.outcome === 'dismissed') {
-      try {
-        window.localStorage.setItem(DISMISS_KEY, '1')
-      } catch {
-        // ignore
-      }
+    const outcome = await install()
+    if (outcome === 'accepted') {
+      toast.success('SkillNote installed — look for it in your dock')
     }
-    setPromptEvent(null)
-    setVisible(false)
   }
-
-  const handleDismiss = () => {
-    try {
-      window.localStorage.setItem(DISMISS_KEY, '1')
-    } catch {
-      // ignore
-    }
-    setVisible(false)
-  }
-
-  if (!visible || !promptEvent) return null
 
   return (
     <div
       role="dialog"
       aria-label="Install SkillNote as an app"
-      className="fixed bottom-20 left-4 right-4 z-50 mx-auto max-w-md rounded-xl border border-border bg-card p-4 shadow-lg lg:bottom-6 lg:left-auto lg:right-6"
+      className="fixed bottom-4 right-4 z-50 flex items-center gap-3 rounded-full border border-border/60 bg-card/95 py-1.5 pl-2 pr-1 shadow-md backdrop-blur-sm"
     >
-      <div className="flex items-start gap-3">
-        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-accent/10 text-accent">
-          <Download className="h-4 w-4" />
-        </div>
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-foreground">Install SkillNote as an app</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Get a dock icon and chromeless window. Same data, no browser tab.
-          </p>
-          <div className="mt-3 flex items-center gap-2">
-            <Button size="sm" onClick={handleInstall}>
-              Install
-            </Button>
-            <Button size="sm" variant="ghost" onClick={handleDismiss}>
-              Not now
-            </Button>
-          </div>
-        </div>
-        <button
-          type="button"
-          onClick={handleDismiss}
-          aria-label="Dismiss install prompt"
-          className="-mr-1 -mt-1 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <X className="h-4 w-4" />
-        </button>
+      <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent/10 text-accent">
+        <Download className="h-3 w-3" />
       </div>
+      <button
+        type="button"
+        onClick={handleInstall}
+        className="text-[13px] font-medium text-foreground hover:text-accent transition-colors"
+      >
+        Install SkillNote as an app
+      </button>
+      <button
+        type="button"
+        onClick={dismissToast}
+        aria-label="Dismiss install prompt"
+        className="inline-flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-3 w-3" />
+      </button>
     </div>
   )
 }

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -5,6 +5,7 @@ import { BookOpen, FolderOpen, Settings, HelpCircle, X, Plug2, BarChart2, Store 
 import { cn } from '@/lib/utils'
 import { useEffect, useMemo, useState } from 'react'
 import { getSkills, syncSkillsFromApi, getConnectionStatus, onConnectionStatusChange } from '@/lib/skills-store'
+import { PWAInstallButton } from '@/components/pwa-install-button'
 
 export function Sidebar({ onClose }: { onClose?: () => void }) {
   const pathname = usePathname()
@@ -149,6 +150,7 @@ export function Sidebar({ onClose }: { onClose?: () => void }) {
           <HelpCircle className="h-[15px] w-[15px] shrink-0" />
           Help
         </a>
+        <PWAInstallButton variant="pill" className="px-2.5 pt-2" />
         <div className="flex items-center gap-1.5 px-2.5 pt-2" title={connStatus === 'online' ? 'Connected to backend' : connStatus === 'offline' ? 'Backend offline' : 'Running locally'}>
           <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', connStatus === 'online' ? 'bg-emerald-500' : connStatus === 'offline' ? 'bg-red-500' : 'bg-amber-500')} />
           <p className="text-[10px] text-[var(--muted-foreground)]/40">

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -150,7 +150,7 @@ export function Sidebar({ onClose }: { onClose?: () => void }) {
           Help
         </a>
         <div className="flex items-center gap-1.5 px-2.5 pt-2" title={connStatus === 'online' ? 'Connected to backend' : connStatus === 'offline' ? 'Backend offline' : 'Running locally'}>
-          <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', connStatus === 'online' ? 'bg-emerald-500' : connStatus === 'offline' ? 'bg-red-500' : 'bg-teal-500')} />
+          <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', connStatus === 'online' ? 'bg-emerald-500' : connStatus === 'offline' ? 'bg-red-500' : 'bg-amber-500')} />
           <p className="text-[10px] text-[var(--muted-foreground)]/40">
             {connStatus === 'online' ? 'Connected' : connStatus === 'offline' ? 'Offline' : 'Admin'}
           </p>

--- a/src/components/pwa-install-button.tsx
+++ b/src/components/pwa-install-button.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { Check, Download } from 'lucide-react'
+import { toast } from 'sonner'
+import { cn } from '@/lib/utils'
+import { usePWAInstall } from '@/lib/use-pwa-install'
+
+interface Props {
+  variant?: 'inline' | 'pill'
+  className?: string
+}
+
+/**
+ * Renders an install affordance the user can keep using even after they
+ * dismissed the auto-toast. Hidden entirely if the browser hasn't fired
+ * `beforeinstallprompt` yet (most often: Safari, or Chrome before the
+ * eligibility heuristic fires), or if the app is already installed.
+ *
+ * `variant="inline"` — for the Settings page (button-style).
+ * `variant="pill"` — for the sidebar footer (tiny dimmed pill).
+ */
+export function PWAInstallButton({ variant = 'inline', className }: Props) {
+  const { canInstall, isInstalled, install } = usePWAInstall()
+
+  // Already installed: show a subtle confirmation in the settings layout,
+  // hide entirely in the sidebar pill (no need to nag users with "installed").
+  if (isInstalled) {
+    if (variant === 'pill') return null
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center gap-1.5 text-[12px] text-muted-foreground',
+          className,
+        )}
+      >
+        <Check className="h-3 w-3 text-emerald-500" />
+        Installed as desktop app
+      </span>
+    )
+  }
+
+  if (!canInstall) return null
+
+  const handleClick = async () => {
+    const outcome = await install()
+    if (outcome === 'accepted') {
+      toast.success('SkillNote installed — look for it in your dock')
+    }
+  }
+
+  if (variant === 'pill') {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        className={cn(
+          'inline-flex items-center gap-1 text-[10px] text-muted-foreground/60 hover:text-accent transition-colors',
+          className,
+        )}
+      >
+        <Download className="h-2.5 w-2.5" />
+        Install app
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border bg-background text-[13px] font-medium text-foreground hover:bg-muted hover:border-accent/40 transition-colors',
+        className,
+      )}
+    >
+      <Download className="h-3.5 w-3.5" />
+      Install as desktop app
+    </button>
+  )
+}

--- a/src/components/skills/skill-card.tsx
+++ b/src/components/skills/skill-card.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils'
 const CARD_ACCENTS = [
   { bg: 'bg-violet-500/10 dark:bg-violet-500/15', text: 'text-violet-600 dark:text-violet-400', border: 'border-violet-500/15', dot: 'bg-violet-400' },
   { bg: 'bg-sky-500/10 dark:bg-sky-500/15', text: 'text-sky-600 dark:text-sky-400', border: 'border-sky-500/15', dot: 'bg-sky-400' },
-  { bg: 'bg-teal-500/10 dark:bg-teal-500/15', text: 'text-teal-600 dark:text-teal-400', border: 'border-teal-500/15', dot: 'bg-teal-400' },
+  { bg: 'bg-emerald-500/10 dark:bg-emerald-500/15', text: 'text-emerald-600 dark:text-emerald-400', border: 'border-emerald-500/15', dot: 'bg-emerald-400' },
   { bg: 'bg-amber-500/10 dark:bg-amber-500/15', text: 'text-amber-600 dark:text-amber-400', border: 'border-amber-500/15', dot: 'bg-amber-400' },
   { bg: 'bg-rose-500/10 dark:bg-rose-500/15', text: 'text-rose-600 dark:text-rose-400', border: 'border-rose-500/15', dot: 'bg-rose-400' },
 ]

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -163,7 +163,7 @@ export const mockSkills: Skill[] = [
     revisions: [
       {
         id: 'r3', rev: 3, label: 'Added code examples and improved formatting', time: '2026-02-20T14:30:00Z',
-        author: 'Nova Vex', avatar_color: '#0d9488', latest: true,
+        author: 'Nova Vex', avatar_color: '#10b981', latest: true,
         diff: [
           { type: 'context', lineOld: 12, lineNew: 12, text: '## Custom Hooks' },
           { type: 'context', lineOld: 13, lineNew: 13, text: '' },
@@ -193,7 +193,7 @@ export const mockSkills: Skill[] = [
       },
       {
         id: 'r1', rev: 1, label: 'Initial version created', time: '2026-02-10T10:00:00Z',
-        author: 'Nova Vex', avatar_color: '#0d9488', latest: false,
+        author: 'Nova Vex', avatar_color: '#10b981', latest: false,
         diff: [],
       },
     ],

--- a/src/lib/use-pwa-install.ts
+++ b/src/lib/use-pwa-install.ts
@@ -1,0 +1,90 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[]
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>
+  prompt: () => Promise<void>
+}
+
+const TOAST_DISMISS_KEY = 'skillnote:pwa-install-dismissed'
+
+interface UsePWAInstall {
+  canInstall: boolean
+  isInstalled: boolean
+  toastDismissed: boolean
+  install: () => Promise<'accepted' | 'dismissed' | 'unavailable'>
+  dismissToast: () => void
+}
+
+/**
+ * Shared PWA install state. One subscriber catches `beforeinstallprompt`;
+ * any number of UI surfaces (toast, settings row, sidebar pill) can render
+ * an install affordance backed by the same prompt event.
+ *
+ * `canInstall` flips to false once the event is consumed or the app is
+ * installed. Dismissing the toast only hides the *toast* — the settings
+ * and sidebar paths stay available so the user can change their mind.
+ */
+export function usePWAInstall(): UsePWAInstall {
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null)
+  const [isInstalled, setIsInstalled] = useState(false)
+  const [toastDismissed, setToastDismissed] = useState(true)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    setIsInstalled(window.matchMedia('(display-mode: standalone)').matches)
+
+    try {
+      setToastDismissed(window.localStorage.getItem(TOAST_DISMISS_KEY) === '1')
+    } catch {
+      // localStorage unavailable — keep toastDismissed=true so we don't flash
+    }
+
+    const onBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault()
+      setPromptEvent(e as BeforeInstallPromptEvent)
+    }
+    const onAppInstalled = () => {
+      setIsInstalled(true)
+      setPromptEvent(null)
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
+    }
+  }, [])
+
+  const install = useCallback(async (): Promise<'accepted' | 'dismissed' | 'unavailable'> => {
+    if (!promptEvent) return 'unavailable'
+    await promptEvent.prompt()
+    const choice = await promptEvent.userChoice
+    if (choice.outcome === 'accepted') {
+      setPromptEvent(null)
+      setIsInstalled(true)
+    }
+    return choice.outcome
+  }, [promptEvent])
+
+  const dismissToast = useCallback(() => {
+    try {
+      window.localStorage.setItem(TOAST_DISMISS_KEY, '1')
+    } catch {
+      // ignore
+    }
+    setToastDismissed(true)
+  }, [])
+
+  return {
+    canInstall: !isInstalled && promptEvent !== null,
+    isInstalled,
+    toastDismissed,
+    install,
+    dismissToast,
+  }
+}


### PR DESCRIPTION
## Summary

Two visual-polish changes bundled in one PR:

1. **Brand**: drop the leftover teal-600 accent (which was clashing with the Connected/online emerald) and unify on emerald-500.
2. **PWA install**: quiet down the auto-toast, plus add persistent install paths in Settings and the sidebar so the user isn't trapped after dismissing.

## 1) Brand: `#0d9488` → `#10b981`

The teal was leftover from an earlier brand pass. The actual brand is "minimal black + emerald accent" — Connected/online pills are already emerald.

| File | Change |
|---|---|
| `src/app/layout.tsx` | viewport `themeColor` → emerald (macOS PWA titlebar) |
| `src/app/manifest.ts` | manifest `theme_color` → emerald (Android address bar) |
| `src/app/globals.css` | `--accent` + `--ring` + `--sidebar-ring` × light & dark — 6 tokens |
| `src/components/skills/skill-card.tsx` | teal tag-palette entry → emerald |
| `src/components/layout/sidebar.tsx` | connection-state "Admin" dot: teal → **amber** (so it doesn't clash with emerald online) |
| `src/lib/mock-data.ts` | seed avatar color (inert, for consistency) |

## 2) PWA install — quieter + multiple persistent paths

Before: one big bottom-card toast. Dismissing was a dead end — only way back was clearing localStorage.

After:
- **Toast** is a slim bottom-right pill (icon + "Install SkillNote as an app" + ×). Single action, no "Not now" duplicate, less visual weight.
- **Settings → Desktop app** section with an "Install as desktop app" button. Shows "✓ Installed as desktop app" if already installed. Hides entirely if browser doesn't support PWA install.
- **Sidebar footer** has a tiny "↓ Install app" pill that appears between Help and the connection-status row. Auto-hidden once installed.

All three surfaces share a single `usePWAInstall()` hook (`src/lib/use-pwa-install.ts`) so the prompt event is consumed once and reflected everywhere.

| File | Change |
|---|---|
| `src/lib/use-pwa-install.ts` | NEW — shared hook |
| `src/components/PWAInstallPrompt.tsx` | refactored, smaller pill |
| `src/components/pwa-install-button.tsx` | NEW — `inline` + `pill` variants |
| `src/app/(app)/settings/page.tsx` | new "Desktop app" section |
| `src/components/layout/sidebar.tsx` | install pill in footer |

## Test plan

- [x] `tsc --noEmit` clean
- [x] zero remaining `#0d9488` / `bg-teal-*` / `text-teal-*` / `border-teal-*` / `ring-teal-*` in `src/`
- [ ] Visual: macOS PWA titlebar shows emerald, not teal
- [ ] Visual: dismissing the toast leaves Settings + Sidebar install paths intact
- [ ] Visual: installing from Settings auto-hides the toast + sidebar pill, shows "✓ Installed as desktop app"

🤖 Generated with [Claude Code](https://claude.com/claude-code)