### PR TITLE
release(0.5.5): bundled-skill marker (closes #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to SkillNote will be documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.5.5] - 2026-05-26
+
+Visibility fix for bundled skills (closes #57). Skills imported from a marketplace, plugin, or `skill_bundle` import source were indistinguishable from locally-authored skills in the grid/list views — the only origin surface was the right-rail `SourceCard` on the detail page, which required clicking into a skill to see. ozp reported that with many bundled skills loaded, the library became hard to scan. This release adds a single small `BundlePill` component used consistently in three places so bundled-vs-local is identifiable at a glance.
+
+No API changes, no schema changes, no breaking changes. The pill detects bundled state from fields the backend already returns (`origin`, `source_path`, `import_source_id`); no migration required.
+
+### Added
+
+- **`BundlePill` component** (`src/components/skills/BundlePill.tsx`). Renders a small `📦 owner/repo` pill when a skill carries an import source. Label fallback chain: `origin.owner/repo` → `source_path` head (before `@`) → `origin.host` → literal `"Bundled"`. Two size variants (`sm` for cards/list rows, `md` for the detail header meta row) and a forked/edited variant (amber background + `·edited` suffix) when the user has diverged from the upstream. Truncates at `max-w-[160px]` for `sm` and `220px` for `md`, with native `title` tooltip exposing the full source path.
+- **`BundlePill` wired into `SkillCard`** (grid view): footer row next to the `v{N}` chip. Flex-wraps below the version chip on narrow cards so the right-side rating star never gets compressed.
+- **`BundlePill` wired into `SkillListItem`** (list view): right-side group before the rating + version chips. Follows the existing `hidden sm:inline-flex` pattern so it shares mobile-hiding behavior with the other meta chips in list rows. Mobile users still see the pill on the grid view, which is the default cards layout at narrow widths.
+- **`BundlePill` wired into `SkillDetail`** header: in the meta pill row immediately after the `Clock | <relative time>` chip and before any collection chips, so source provenance reads with the skill-intrinsic chips rather than after categorization chips. The right-rail `SourceCard` is preserved untouched — it still carries the full repo/branch/sha/path breakdown for users who want the detail.
+
+### Deferred (intentionally out of scope)
+
+- **Sources management page.** Could list every `import_source` with its skills, last-synced status, and drift indicators. Held back until users actually have enough bundled skills to need a management surface — premature dashboarding tends to clutter.
+- **Bulk actions on bundled skills.** Multi-select to refresh / unpin / delete an entire bundle at once. Same reasoning — wait for the pain to be reported.
+- **Filter facet for `Source` on the home page.** A "Local / Bundled / per-source" filter axis alongside Collections would solve organization-at-scale, but #57's reported problem is scannability (a visual identity gap), not filtering. Shipping the pill first lets us see whether the filter is still wanted once bundled skills are visually distinct.
+
+### Internal
+
+- **Frontend-only release.** Touched files: `src/components/skills/BundlePill.tsx` (new, 70 LOC), `src/components/skills/skill-card.tsx` (+2 LOC), `src/components/skills/skill-list-item.tsx` (+2 LOC), `src/components/skills/skill-detail.tsx` (+2 LOC). No backend changes; the `origin` object on `SkillListItem` / `SkillDetail` API responses already carried everything the pill needs.
+
 ## [0.5.4] - 2026-05-15
 
 Hotfix release for a post-0.5.3 `/analytics` page crash. Single bug, plus an audit pass to verify no related null-safety issues lurking elsewhere.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillnote",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "overrides": {
     "hono": "4.12.18",

--- a/src/components/skills/BundlePill.tsx
+++ b/src/components/skills/BundlePill.tsx
@@ -1,0 +1,70 @@
+import { Package } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { Skill } from '@/lib/mock-data'
+
+type Size = 'sm' | 'md'
+type PillSkill = Pick<Skill, 'origin' | 'source_path' | 'import_source_id' | 'forked_from_source'>
+
+function isBundled(skill: PillSkill): boolean {
+  return !!skill.origin || !!skill.import_source_id || !!skill.source_path
+}
+
+function isEdited(skill: PillSkill): boolean {
+  return !!skill.forked_from_source || !!skill.origin?.forked
+}
+
+function deriveLabel(skill: PillSkill): string {
+  const o = skill.origin
+  if (o?.owner && o?.repo) return `${o.owner}/${o.repo}`
+  if (skill.source_path) {
+    const head = skill.source_path.split('@')[0]
+    if (head) return head
+  }
+  if (o?.host) return o.host
+  return 'Bundled'
+}
+
+function deriveTitle(skill: PillSkill): string {
+  const base = skill.source_path || skill.origin?.url || deriveLabel(skill)
+  return isEdited(skill) ? `${base} · edited locally` : `Bundled from ${base}`
+}
+
+export function BundlePill({
+  skill,
+  size = 'sm',
+  className,
+}: {
+  skill: PillSkill
+  size?: Size
+  className?: string
+}) {
+  if (!isBundled(skill)) return null
+
+  const label = deriveLabel(skill)
+  const title = deriveTitle(skill)
+  const edited = isEdited(skill)
+
+  const sizing =
+    size === 'md'
+      ? 'h-[22px] px-2 text-[11px] gap-1.5'
+      : 'h-[18px] px-1.5 text-[10px] gap-1'
+  const iconSize = size === 'md' ? 'h-3 w-3' : 'h-2.5 w-2.5'
+
+  return (
+    <span
+      title={title}
+      className={cn(
+        'inline-flex items-center rounded font-medium max-w-[160px] shrink-0',
+        sizing,
+        edited
+          ? 'bg-amber-500/10 text-amber-700 dark:text-amber-400'
+          : 'bg-muted/60 text-muted-foreground/70',
+        className,
+      )}
+    >
+      <Package className={cn(iconSize, 'shrink-0')} />
+      <span className="truncate font-mono">{label}</span>
+      {edited && <span className="ml-0.5 opacity-70">·edited</span>}
+    </span>
+  )
+}

--- a/src/components/skills/skill-card.tsx
+++ b/src/components/skills/skill-card.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { Skill } from '@/lib/mock-data'
 import { MessageSquare, Paperclip, Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { BundlePill } from './BundlePill'
 
 const CARD_ACCENTS = [
   { bg: 'bg-violet-500/10 dark:bg-violet-500/15', text: 'text-violet-600 dark:text-violet-400', border: 'border-violet-500/15', dot: 'bg-violet-400' },
@@ -61,12 +62,13 @@ export function SkillCard({ skill, rating }: { skill: Skill; rating?: { avg_rati
           {skill.description}
         </p>
         <div className="flex items-center justify-between pt-3 border-t border-border/30">
-          <div className="flex gap-1.5 flex-wrap items-center">
+          <div className="flex gap-1.5 flex-wrap items-center min-w-0">
             {skill.current_version > 0 && (
               <span className="text-[10px] font-mono font-medium text-accent/70 bg-accent/10 px-1.5 py-0.5 rounded-md">
                 v{skill.current_version}
               </span>
             )}
+            <BundlePill skill={skill} />
           </div>
           {rating && rating.rating_count > 0 && rating.avg_rating != null && (
             <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400">

--- a/src/components/skills/skill-detail.tsx
+++ b/src/components/skills/skill-detail.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link'
 import { SkillViewTab } from './tabs/SkillViewTab'
 import { SkillEditTab } from './tabs/SkillEditTab'
 import { InstallDialog } from './InstallDialog'
+import { BundlePill } from './BundlePill'
 
 type PaletteAction = {
   icon: React.ComponentType<{ className?: string }>
@@ -546,6 +547,7 @@ export function SkillDetail({ skill, onSkillUpdated }: { skill: Skill; onSkillUp
                       <Clock className="h-3 w-3" />
                       {formatRelative(skill.updated_at)}
                     </span>
+                    <BundlePill skill={skill} size="md" className="rounded-full px-2.5 py-1 max-w-[220px]" />
                     {ratingDetail && ratingDetail.rating_count > 0 && ratingDetail.avg_rating != null && (
                       <button
                         onClick={() => document.getElementById('agent-reviews')?.scrollIntoView({ behavior: 'smooth' })}

--- a/src/components/skills/skill-list-item.tsx
+++ b/src/components/skills/skill-list-item.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation'
 import { FileText, MessageSquare, Paperclip, FolderOpen, Star } from 'lucide-react'
 import { Skill } from '@/lib/mock-data'
 import { cn } from '@/lib/utils'
+import { BundlePill } from './BundlePill'
 
 export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_rating: number | null; rating_count: number } }) {
   const router = useRouter()
@@ -71,6 +72,7 @@ export function SkillListItem({ skill, rating }: { skill: Skill; rating?: { avg_
         </div>
 
         <div className="flex items-center gap-2 shrink-0">
+          <BundlePill skill={skill} className="hidden sm:inline-flex" />
           {rating && rating.rating_count > 0 && rating.avg_rating != null && (
             <span className="flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400 hidden sm:flex">
               <Star className="h-3 w-3 fill-amber-400 text-amber-400" />


### PR DESCRIPTION
## Summary

- Adds a `BundlePill` component that renders a `📦 owner/repo` chip on bundled skills in the grid card, list row, and detail header meta row — so users can identify upstream-managed skills at a glance (closes #57).
- Forked/edited skills get an amber variant with a `·edited` suffix; reuses the convention already established by the `SourceCard` "Edited" badge.
- Frontend-only; uses fields the backend already returns (`origin`, `source_path`, `import_source_id`). No schema, API, or migration changes.

## Why this scope

ozp's complaint in #57 was twofold: bundled skills weren't visible at a glance, and they felt like a "special type." The first is a visual-identity problem; the second is an information-architecture problem. Shipping one consistent pill in all three skill-listing surfaces solves the visibility complaint cleanly. The IA side (filter facets, sources management page, bulk actions) is intentionally deferred — premature dashboarding tends to clutter, and we don't yet have signal that users have enough bundles to need it. Once bundled skills are visually distinct, we can see whether filtering is still wanted.

## Test plan

- [x] Card view (light + dark, desktop): pill renders with `v{N}` and rating, truncates long owner/repo, wraps under v-chip on narrow cards
- [x] List view (light + dark, desktop): pill renders on right side before rating/version chips
- [x] List view (mobile <640px): pill hidden via `hidden sm:inline-flex` — consistent with existing meta-chip pattern
- [x] Grid view (mobile <640px): pill renders prominently in single-column card footer
- [x] Detail page meta row: pill sits next to `v{N} | <relative time>` chips (skill-intrinsic), before collection chips
- [x] Forked/edited variant: amber tint + `·edited` suffix renders in both light/dark
- [x] Non-bundled skill: pill correctly absent
- [x] Edge cases verified: long owner/repo truncates with ellipsis; origin without owner/repo falls back to `host`; missing host falls back to literal "Bundled"
- [x] `npm run build` clean
- [x] `npx tsc --noEmit` clean
- [x] No console errors during navigation

## Release surfaces affected

- `package.json` bumped to `0.5.5`
- `CHANGELOG.md` entry for `[0.5.5]` added
- CLI version unchanged (no CLI changes)
- After merge: tag `v0.5.5` → `docker-images.yml` publishes `ghcr.io/luna-prompts/skillnote-{web,api}:0.5.5` + `:latest`
- No npm publish (CLI untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)