### PR TITLE
chore(cli): sync version to 0.5.5

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillnote",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillnote",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillnote",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Self-hosted skill registry for AI coding agents",
   "license": "MIT",
   "homepage": "https://github.com/luna-prompts/skillnote",


### PR DESCRIPTION
## Summary

No-op CLI version bump to keep `cli/package.json` aligned with the root `package.json` 0.5.5 release shipped in #58. Required for the established release convention: every 0.5.x release tag is `cli-v0.5.X`, which fires both `cli-release.yml` (npm publish) and `docker-images.yml` (GHCR web/api push) in parallel.

Without this sync, the `cli-release.yml` workflow would fail its tag-vs-package-version check.

## Files

- `cli/package.json`: `0.5.4` → `0.5.5`
- `cli/package-lock.json`: lockfile auto-regenerated by `npm version`

No source changes. The CLI binary itself is functionally identical to 0.5.4.

## Test plan

- [x] `cli/package.json` version field updated
- [x] `cli/package-lock.json` lockfile re-synced via `npm version 0.5.5 --no-git-tag-version`
- [ ] After merge, tagging `cli-v0.5.5` will pass the version-match guard in `cli-release.yml:33-40`

🤖 Generated with [Claude Code](https://claude.com/claude-code)