### PR TITLE
fix(imports): allow namespaced skill names and surface skipped skills…

### DIFF
--- a/backend/app/services/imports/manifest_schema.py
+++ b/backend/app/services/imports/manifest_schema.py
@@ -10,7 +10,7 @@ from typing import List, Literal, Optional, Union
 from pydantic import BaseModel, Field, field_validator
 
 
-SKILL_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+SKILL_NAME_RE = re.compile(r"^[a-z0-9_-]+(?::[a-z0-9_-]+)?$")
 RESERVED_WORDS = ("anthropic", "claude")
 
 
@@ -100,7 +100,7 @@ class SkillFrontmatter(BaseModel):
         if len(v) > 64:
             raise ValueError(f"Name must be <=64 chars (got {len(v)})")
         if not SKILL_NAME_RE.match(v):
-            raise ValueError("Name must match ^[a-z0-9-]+$")
+            raise ValueError("Name must use only lowercase letters, numbers, hyphens, and underscores, with an optional namespace prefix (e.g. ns:name)")
         for word in RESERVED_WORDS:
             if word in v:
                 raise ValueError(f"Name cannot contain reserved word '{word}'")

--- a/backend/app/validators/skill_validator.py
+++ b/backend/app/validators/skill_validator.py
@@ -3,7 +3,7 @@ import re
 NAME_MAX = 64
 DESC_MAX = 1024
 MAX_SKILLS_PER_COLLECTION = 15
-NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
+NAME_PATTERN = re.compile(r"^[a-z0-9_-]+(?::[a-z0-9_-]+)?$")
 XML_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
 RESERVED_WORDS = ["anthropic", "claude"]
 
@@ -17,7 +17,7 @@ def validate_skill_name(name: str) -> list[str]:
     if len(name) > NAME_MAX:
         errors.append(f"Name must be {NAME_MAX} characters or fewer")
     if not NAME_PATTERN.match(name):
-        errors.append("Name must contain only lowercase letters, numbers, and hyphens")
+        errors.append("Name must use only lowercase letters, numbers, hyphens, and underscores, with an optional namespace prefix (e.g. ns:name)")
     for word in RESERVED_WORDS:
         if word in name:
             errors.append(f'Name cannot contain reserved word "{word}"')

--- a/backend/tests/unit/test_manifest_schema.py
+++ b/backend/tests/unit/test_manifest_schema.py
@@ -97,3 +97,34 @@ def test_skill_description_too_long():
 def test_skill_name_too_long():
     with pytest.raises(ValidationError):
         SkillFrontmatter.model_validate({"name": "a" * 65, "description": "fine"})
+
+
+# namespace prefix (ns:name) cases
+def test_skill_frontmatter_namespaced_name_valid():
+    fm = SkillFrontmatter.model_validate({"name": "ckm:my-skill", "description": "Does stuff."})
+    assert fm.name == "ckm:my-skill"
+
+def test_skill_frontmatter_namespaced_hyphens_valid():
+    fm = SkillFrontmatter.model_validate({"name": "a-b:c-d", "description": "Fine."})
+    assert fm.name == "a-b:c-d"
+
+def test_skill_frontmatter_multiple_colons_rejected():
+    with pytest.raises(ValidationError):
+        SkillFrontmatter.model_validate({"name": "a:b:c", "description": "bad"})
+
+def test_skill_frontmatter_leading_colon_rejected():
+    with pytest.raises(ValidationError):
+        SkillFrontmatter.model_validate({"name": ":name", "description": "bad"})
+
+def test_skill_frontmatter_trailing_colon_rejected():
+    with pytest.raises(ValidationError):
+        SkillFrontmatter.model_validate({"name": "ns:", "description": "bad"})
+
+def test_skill_frontmatter_namespaced_max_length_boundary():
+    name = "a" * 31 + ":" + "b" * 32  # 64 chars total
+    fm = SkillFrontmatter.model_validate({"name": name, "description": "Fine."})
+    assert fm.name == name
+
+def test_skill_frontmatter_namespaced_max_length_exceeded():
+    with pytest.raises(ValidationError):
+        SkillFrontmatter.model_validate({"name": "a" * 32 + ":" + "b" * 32, "description": "fine"})

--- a/backend/tests/unit/test_slugify_and_validation.py
+++ b/backend/tests/unit/test_slugify_and_validation.py
@@ -125,13 +125,46 @@ class TestValidateSkillName:
         errors = validate_skill_name("<script>alert</script>")
         assert len(errors) > 0
 
-    def test_underscores_rejected(self):
-        errors = validate_skill_name("my_skill")
-        assert any("lowercase" in e.lower() or "hyphens" in e.lower() for e in errors)
+    def test_underscores_allowed(self):
+        assert validate_skill_name("my_skill") == []
 
     def test_special_chars_specific_error(self):
         errors = validate_skill_name("my@skill!")
         assert any("lowercase" in e.lower() or "hyphens" in e.lower() for e in errors)
+
+    # namespace prefix (ns:name) cases
+    def test_namespaced_name_valid(self):
+        assert validate_skill_name("ckm:my-skill") == []
+
+    def test_namespaced_name_with_hyphens_valid(self):
+        assert validate_skill_name("a-b:c-d") == []
+
+    def test_namespaced_name_max_length_boundary(self):
+        # 31 chars ns + colon + 32 chars local = 64 total
+        assert validate_skill_name("a" * 31 + ":" + "b" * 32) == []
+
+    def test_namespaced_name_max_length_exceeded(self):
+        errors = validate_skill_name("a" * 32 + ":" + "b" * 32)
+        assert any("64" in e or "fewer" in e.lower() for e in errors)
+
+    def test_multiple_colons_rejected(self):
+        errors = validate_skill_name("a:b:c")
+        assert len(errors) > 0
+
+    def test_leading_colon_rejected(self):
+        errors = validate_skill_name(":name")
+        assert len(errors) > 0
+
+    def test_trailing_colon_rejected(self):
+        errors = validate_skill_name("ns:")
+        assert len(errors) > 0
+
+    def test_namespaced_uppercase_rejected(self):
+        errors = validate_skill_name("NS:name")
+        assert len(errors) > 0
+
+    def test_namespaced_underscore_allowed(self):
+        assert validate_skill_name("ns:my_skill") == []
 
 
 # ── validate_skill_description tests ─────────────────────────────────

--- a/src/components/browse/ImportSheet.tsx
+++ b/src/components/browse/ImportSheet.tsx
@@ -62,7 +62,8 @@ export function ImportSheet({ onClose, onImported }: { onClose: () => void; onIm
         skill_selection: [...selection],
         on_conflict: globalConflict,
       })
-      toast.success(`Imported ${r.imported.length} skills from ${state.data.source.owner}/${state.data.source.repo}`)
+      const skippedCount = r.skipped?.length ?? 0
+      toast.success(`Imported ${r.imported.length} skill${r.imported.length === 1 ? '' : 's'} from ${state.data.source.owner}/${state.data.source.repo}${skippedCount ? ` · ${skippedCount} skipped` : ''}`)
       setState({ kind: 'success' })
       onImported()
       setTimeout(onClose, 500)

--- a/src/components/browse/ImportWorkspace.tsx
+++ b/src/components/browse/ImportWorkspace.tsx
@@ -38,6 +38,7 @@ const MAX_SKILLS_PER_COLLECTION = 15
 type ApplyResult = {
   imported: number
   renamed: number
+  skipped: number
   collection_slug: string
 }
 
@@ -188,12 +189,14 @@ export function ImportWorkspace({
       setProgress(100)
       setProgressLabel('Done')
       const renamed = r.imported.filter((s) => s.renamed_reason).length
+      const skipped = r.skipped?.length ?? 0
       toast.success(
-        `Imported ${r.imported.length} skill${r.imported.length === 1 ? '' : 's'} into ${r.collection_slug}${renamed ? ` · ${renamed} renamed` : ''}`,
+        `Imported ${r.imported.length} skill${r.imported.length === 1 ? '' : 's'} into ${r.collection_slug}${renamed ? ` · ${renamed} renamed` : ''}${skipped ? ` · ${skipped} skipped` : ''}`,
       )
       setResult({
         imported: r.imported.length,
         renamed,
+        skipped,
         collection_slug: r.collection_slug,
       })
       setStage('done')
@@ -1107,6 +1110,11 @@ function DoneCard({
         {result.renamed > 0 && ` · ${result.renamed} renamed to avoid conflicts`}
         . Everything is ready in your library.
       </p>
+      {result.skipped > 0 && (
+        <p className="mt-2 max-w-md text-[12px] text-amber-600 dark:text-amber-400">
+          {result.skipped} skill{result.skipped === 1 ? '' : 's'} skipped — name validation failed. Check that skill names use only lowercase letters, numbers, hyphens, or a namespace prefix (e.g. ns:name).
+        </p>
+      )}
       <div className="mt-7 flex flex-col items-stretch gap-2 sm:flex-row">
         <Button variant="outline" onClick={onAddAnother}>
           <Plus className="mr-1.5 h-3.5 w-3.5" />

--- a/src/lib/skill-validation.ts
+++ b/src/lib/skill-validation.ts
@@ -3,7 +3,7 @@
 export const NAME_MAX = 64
 export const DESC_MAX = 1024
 
-const NAME_PATTERN = /^[a-z0-9-]+$/
+const NAME_PATTERN = /^[a-z0-9_-]+(?::[a-z0-9_-]+)?$/
 const RESERVED_WORDS = ['anthropic', 'claude']
 const XML_TAG_RE = /<\/?[a-zA-Z][^>]*>/
 
@@ -19,7 +19,7 @@ export function validateSkillName(name: string): ValidationError[] {
     errors.push({ field: 'name', message: `Name must be ${NAME_MAX} characters or fewer (currently ${name.length})` })
   }
   if (!NAME_PATTERN.test(name)) {
-    errors.push({ field: 'name', message: 'Only lowercase letters, numbers, and hyphens allowed' })
+    errors.push({ field: 'name', message: 'Only lowercase letters, numbers, hyphens, underscores, and an optional namespace prefix allowed (e.g. ns:name)' })
   }
   for (const word of RESERVED_WORDS) {
     if (name.includes(word)) {
@@ -60,18 +60,25 @@ export function validateCollections(collections: string[]): ValidationError[] {
  * Use on every keystroke in name inputs so the user sees the result live.
  */
 export function normalizeSkillName(raw: string): string {
-  return raw
+  const s = raw
     .toLowerCase()
-    .replace(/\s+/g, '-')       // spaces → hyphens (Slack-style)
-    .replace(/[^a-z0-9-]/g, '') // strip anything invalid
-    .replace(/-+/g, '-')        // collapse consecutive hyphens
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9_:-]/g, '')
+    .replace(/-+/g, '-')
+  // Enforce at most one colon in ns:local form; strip any extra colons
+  const [ns, ...rest] = s.split(':')
+  if (rest.length === 0) return ns
+  return `${ns}:${rest.join('').replace(/:/g, '')}`
 }
 
 export function slugFromName(name: string): string {
-  return name
+  const s = name
     .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[^a-z0-9\s_:-]/g, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
+  const [ns, ...rest] = s.split(':')
+  if (rest.length === 0) return ns
+  return `${ns}:${rest.join('').replace(/:/g, '')}`
 }


### PR DESCRIPTION
## Summary

- Expand skill name validation to accept a namespace prefix (`ns:name`), e.g. `ckm:my-skill`. The new pattern `^[a-z0-9_-]+(?::[a-z0-9_-]+)?$` allows lowercase letters, digits, hyphens, underscores, and exactly one colon as a namespace separator.
- Update all three validation layers in sync: `skill_validator.py`, `manifest_schema.py`, and `skill-validation.ts` (including `normalizeSkillName` / `slugFromName`).
- Show skipped skills after import — `ImportWorkspace` and `ImportSheet` now include a skipped count in the toast and a warning in the done card when the API returns `skipped[]` entries.

## Test plan

- [ ] `cd backend && pytest backend/tests/unit/test_slugify_and_validation.py backend/tests/unit/test_manifest_schema.py -v` — new namespace cases (valid: `ckm:my-skill`, `ns:my_skill`; invalid: `a:b:c`, `:name`, `ns:`) all pass
- [ ] Import a repo containing skills with namespaced `name:` frontmatter and confirm they appear in the imported list rather than being silently dropped
- [ ] Import a repo where some skills have invalid names — confirm the toast and done card show the skipped count

🤖 Generated with [Claude Code](https://claude.com/claude-code)
