### PR TITLE
fix(api): drop content_md from GET /v1/skills list response (closes #65)

### DIFF
--- a/backend/app/api/skills.py
+++ b/backend/app/api/skills.py
@@ -152,7 +152,6 @@ def list_skills(
                 slug=skill.slug,
                 description=skill.description,
                 collections=skill.collections or [],
-                content_md=skill.content_md or "",
                 latestVersion=latest.version if latest else None,
                 status=latest.status if latest else None,
                 channel=latest.channel if latest else None,

--- a/backend/app/schemas/skill.py
+++ b/backend/app/schemas/skill.py
@@ -33,7 +33,6 @@ class SkillListItem(BaseModel):
     status: Optional[str] = None
     channel: Optional[str] = None
     currentVersion: int = 0
-    content_md: Optional[str] = ""
     extra_frontmatter: Optional[str] = None
     origin: Optional[SkillOrigin] = None
 

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -19,7 +19,6 @@ type ApiSkillListItem = {
   slug: string
   description: string
   collections?: string[]
-  content_md?: string
   latestVersion?: string
   currentVersion?: number
   extra_frontmatter?: string
@@ -76,7 +75,7 @@ function listItemToSkill(item: ApiSkillListItem): Skill {
     slug: item.slug,
     title: item.name,
     description: item.description,
-    content_md: item.content_md || '',
+    content_md: '',
     collections: item.collections || [],
     current_version: item.currentVersion || 0,
     extra_frontmatter: item.extra_frontmatter ?? undefined,

--- a/src/lib/skills-store.ts
+++ b/src/lib/skills-store.ts
@@ -84,10 +84,11 @@ function notifyChanged(): void {
 function commitSkills(skills: Skill[]): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(skills))
-  } catch {
+  } catch (err) {
     // SecurityError on Safari private / QuotaExceededError on full —
     // expected on locked-down browsers. The notify still fires so any
     // optimistic in-memory state gets a chance to reconcile.
+    console.warn('[skillnote] localStorage write failed:', err)
   }
   notifyChanged()
 }


### PR DESCRIPTION
## Summary

- Remove `content_md` from `SkillListItem` (backend schema + list endpoint constructor) — reduces the list payload from ~6 MB to ~270 KB for a 400-skill library.
- Drop `content_md?: string` from the `ApiSkillListItem` frontend type; `listItemToSkill()` now initialises `content_md` to `''` and relies on the existing `syncSkillsFromApi()` fallback to restore previously-cached content from localStorage.
- Add `console.warn` in `commitSkills()` so `QuotaExceededError` is visible in DevTools instead of being swallowed silently.

The detail endpoint (`GET /v1/skills/{slug}`) is unchanged and continues to return the full body, so skill content loads correctly when a skill is opened.

## Test plan

- [ ] `GET /v1/skills` response contains no `content_md` keys
- [ ] Opening a skill detail page still renders content (fetched via detail endpoint)
- [ ] `npx playwright test` passes — E2E mocks already strip `content_md` from list responses
- [ ] With a large library, localStorage stays within quota (check Application → Storage in DevTools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
