### PR TITLE
chore(cli): sync version to 0.5.6 (fixes failed npm publish)

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillnote",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillnote",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillnote",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Self-hosted skill registry for AI coding agents",
   "license": "MIT",
   "homepage": "https://github.com/luna-prompts/skillnote",


### PR DESCRIPTION
## Problem

The `0.5.6` npm publish never happened. `npm view skillnote version` still reports `0.5.5`.

**Root cause:** The npm package is published from `cli/`, which has its own version field. The `0.5.6` bump commit (`9a4a7e9`) only updated the **root** `package.json` and left `cli/package.json` at `0.5.5`. When the `cli-v0.5.6` tag fired `cli-release.yml`, the **"Verify version matches tag"** guard failed (tag `0.5.6` ≠ package `0.5.5`) and exited before `npm publish` ever ran.

This is the same step that PR #59 handled for the `0.5.5` release — a dedicated CLI version-sync commit. That sync was skipped for `0.5.6`.

## Fix

Bump `cli/package.json` + `cli/package-lock.json` from `0.5.5` → `0.5.6`. No CLI code changes.

- ✅ Workflow guard now passes locally: tag `0.5.6` == package `0.5.6`
- ✅ No version skipped: npm goes `0.5.5` → `0.5.6` (contiguous)

## After merge — re-fire the release

The existing `cli-v0.5.6` tag points at a commit where `cli/package.json` is still `0.5.5`, so it must be re-pointed at the merge commit:

```bash
git push origin :refs/tags/cli-v0.5.6   # delete old remote tag
git tag -d cli-v0.5.6                    # delete old local tag
git tag cli-v0.5.6 <merge-commit-sha>   # re-tag the fixed commit
git push origin cli-v0.5.6              # re-fire cli-release.yml
```

> Note (separate, non-blocking): `CHANGELOG.md` has no `0.5.6` entry yet. Doesn't affect npm publish (git-only), but worth adding in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)