### PR TITLE
ci(cli-smoke): pass --passWithNoTests for the empty smoke dir

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -42,5 +42,9 @@ jobs:
       - name: Run skillnote --version
         run: cd /tmp/sn-smoke && npx skillnote --version
       - name: Run smoke tests
-        run: npm run test -- tests/smoke
+        # tests/smoke/ is currently empty (and excluded from the default vitest
+        # run). vitest 3 exits 1 on "no test files found" (vitest 2 passed), so
+        # pass explicitly until smoke specs exist. The real smoke validation is
+        # the npm-pack + `skillnote --version` steps above.
+        run: npm run test -- tests/smoke --passWithNoTests
         timeout-minutes: 15


### PR DESCRIPTION
The `cli-smoke` workflow went red after the 0.6.0 release: bumping `vitest` 2→3 (to fix the UI-server RCE advisory) changed the "no test files found" exit code from 0 to 1. `cli/tests/smoke/` is empty and excluded from the default vitest run, so the job's `vitest run tests/smoke` now fails vacuously.

Fix: add `--passWithNoTests` (restores the vitest-2 behavior). The actual smoke validation — `npm pack` + install + `skillnote --version` — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)