### PR TITLE
feat(codex): add global skill sync integration

### DIFF
--- a/backend/app/api/downloads.py
+++ b/backend/app/api/downloads.py
@@ -1,7 +1,10 @@
 import hashlib
+import io
+import json
+import zipfile
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from sqlalchemy.orm import Session
 
 from app.core.errors import api_error
@@ -10,6 +13,58 @@ from app.db.session import get_db
 from app.services.storage_service import storage
 
 router = APIRouter(prefix="/v1/skills", tags=["downloads"])
+
+
+@router.get("/{skill}/current/download")
+def download_current_skill_bundle(
+    skill: str,
+    db: Session = Depends(get_db),
+):
+    """Build a bundle from the current UI content, even when it was never published."""
+    skill_row = (
+        db.query(Skill)
+        .filter((Skill.slug == skill) | (Skill.name == skill))
+        .first()
+    )
+    if not skill_row:
+        raise api_error(404, "SKILL_NOT_FOUND", "Skill not found")
+
+    # JSON string/list syntax is valid YAML and safely handles colons, quotes,
+    # newlines, and non-ASCII text without adding a PyYAML formatting dependency
+    # to the download path.
+    frontmatter = [
+        f"name: {json.dumps(skill_row.slug, ensure_ascii=False)}",
+        f"description: {json.dumps(skill_row.description or '', ensure_ascii=False)}",
+    ]
+    if skill_row.collections:
+        frontmatter.append(
+            f"collections: {json.dumps(skill_row.collections, ensure_ascii=False)}"
+        )
+    if skill_row.extra_frontmatter and skill_row.extra_frontmatter.strip():
+        frontmatter.append(skill_row.extra_frontmatter.strip())
+
+    content = (
+        "---\n"
+        + "\n".join(frontmatter)
+        + "\n---\n\n"
+        + (skill_row.content_md or "")
+    ).encode("utf-8")
+    bundle = io.BytesIO()
+    with zipfile.ZipFile(bundle, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("SKILL.md", content)
+    payload = bundle.getvalue()
+    checksum = hashlib.sha256(payload).hexdigest()
+    current_version = str(skill_row.current_version or 0)
+    return Response(
+        content=payload,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{skill_row.slug}-current.zip"',
+            "X-Skill-Name": skill_row.slug,
+            "X-Skill-Version": f"current-{current_version}",
+            "X-Checksum-Sha256": checksum,
+        },
+    )
 
 
 @router.get("/{skill}/{version}/download")

--- a/backend/app/api/setup.py
+++ b/backend/app/api/setup.py
@@ -18,8 +18,8 @@ router = APIRouter(tags=["setup"])
 
 # Agents the Connect page understands. Keep the canonical names in sync
 # with the frontend's `AgentId` union and with the install scripts below.
-SUPPORTED_AGENTS = ("claude-code", "openclaw", "claude-ai")
-AgentLiteral = Literal["claude-code", "openclaw", "claude-ai"]
+SUPPORTED_AGENTS = ("claude-code", "codex", "openclaw", "claude-ai")
+AgentLiteral = Literal["claude-code", "codex", "openclaw", "claude-ai"]
 
 # Buckets for the per-agent state machine on the Connect page.
 ACTIVE_WINDOW_HOURS = 24
@@ -622,6 +622,317 @@ def get_claude_ai_setup_script(request: Request):
     return PlainTextResponse(script, media_type="text/plain")
 
 
+_CODEX_SYNC_SCRIPT = r'''#!/usr/bin/env python3
+"""Refresh SkillNote-managed skills in Codex's global skill directory."""
+import json
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+import zipfile
+
+
+def main():
+    quiet = "--quiet" in sys.argv
+    args = [arg for arg in sys.argv[1:] if arg != "--quiet"]
+    if len(args) != 3:
+        print("usage: sync.py [--quiet] API_URL SKILLS_DIR MANIFEST", file=sys.stderr)
+        return 2
+
+    api_url, skills_dir, manifest_path = args
+    source_slug_re = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+    local_slug_re = re.compile(r"^[a-z0-9][a-z0-9-]{0,127}$")
+
+    def local_slug(source_slug):
+        value = re.sub(r"[^a-z0-9-]+", "-", source_slug.lower())
+        value = re.sub(r"-+", "-", value).strip("-")
+        return value
+
+    def get_json(url):
+        with urllib.request.urlopen(url, timeout=10) as response:
+            return json.load(response)
+
+    def safe_extract(bundle, destination):
+        with zipfile.ZipFile(bundle) as archive:
+            root = os.path.realpath(destination)
+            for entry in archive.infolist():
+                name = entry.filename.replace("\\", "/")
+                target = os.path.realpath(os.path.join(root, name))
+                mode = (entry.external_attr >> 16) & 0o170000
+                if name.startswith("/") or (target != root and not target.startswith(root + os.sep)):
+                    raise RuntimeError("bundle contains an unsafe path")
+                if mode == stat.S_IFLNK:
+                    raise RuntimeError("bundle contains a symbolic link")
+            archive.extractall(root)
+
+    try:
+        with open(manifest_path, encoding="utf-8") as handle:
+            previous = json.load(handle)
+    except (OSError, ValueError):
+        previous = {}
+    previous_slugs = set(previous.get("skills", []))
+
+    try:
+        catalog = get_json(api_url.rstrip("/") + "/v1/skills")
+    except Exception as exc:
+        if not quiet:
+            print("  SkillNote sync failed: %s" % exc, file=sys.stderr)
+        return 0 if quiet else 1
+
+    os.makedirs(skills_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
+    installed = []
+    failed = []
+    for skill in catalog:
+        source_slug = str(skill.get("slug", ""))
+        slug = local_slug(source_slug)
+        published_version = skill.get("latestVersion")
+        content_version = int(skill.get("currentVersion") or 0)
+        if not source_slug_re.fullmatch(source_slug) or not local_slug_re.fullmatch(slug):
+            continue
+        encoded_slug = urllib.parse.quote(source_slug, safe="")
+        # Published, unedited skills retain their complete stored bundle
+        # (including scripts/references). Imported or UI-authored/edited skills
+        # may have no published SkillVersion, so bundle their current DB content.
+        if published_version and content_version == 0:
+            version = published_version
+            url = "%s/v1/skills/%s/%s/download" % (
+                api_url.rstrip("/"), encoded_slug, published_version,
+            )
+        else:
+            version = "current-%d" % content_version
+            url = "%s/v1/skills/%s/current/download" % (
+                api_url.rstrip("/"), encoded_slug,
+            )
+        try:
+            with tempfile.TemporaryDirectory(prefix="skillnote-codex-") as staging:
+                bundle = os.path.join(staging, "bundle.zip")
+                extracted = os.path.join(staging, "skill")
+                os.makedirs(extracted)
+                urllib.request.urlretrieve(url, bundle)
+                safe_extract(bundle, extracted)
+                skill_md = os.path.join(extracted, "SKILL.md")
+                if not os.path.isfile(skill_md):
+                    raise RuntimeError("bundle has no root SKILL.md")
+                # Some imported registries use names such as `ckm:brand`.
+                # Keep the API slug for fetching, but normalize the local
+                # directory/frontmatter name for Windows and Codex portability.
+                with open(skill_md, encoding="utf-8") as handle:
+                    skill_text = handle.read()
+                skill_text, replacements = re.subn(
+                    r"(?m)^name:\s*.*$",
+                    "name: " + json.dumps(slug, ensure_ascii=False),
+                    skill_text,
+                    count=1,
+                )
+                if replacements != 1:
+                    raise RuntimeError("SKILL.md has no frontmatter name")
+                with open(skill_md, "w", encoding="utf-8", newline="\n") as handle:
+                    handle.write(skill_text)
+                destination = os.path.join(skills_dir, slug)
+                if os.path.exists(destination) and slug not in previous_slugs:
+                    raise RuntimeError("destination already exists and is not managed by SkillNote")
+                replacement = destination + ".skillnote-new"
+                shutil.rmtree(replacement, ignore_errors=True)
+                shutil.copytree(extracted, replacement)
+                shutil.rmtree(destination, ignore_errors=True)
+                os.replace(replacement, destination)
+            installed.append(slug)
+            if not quiet:
+                alias = " as %s" % slug if source_slug != slug else ""
+                print("  Installed %s@%s%s" % (source_slug, version, alias))
+        except Exception as exc:
+            failed.append(slug)
+            if not quiet:
+                print("  Warning: %s could not be installed: %s" % (source_slug, exc), file=sys.stderr)
+
+    retained = previous_slugs.intersection(failed)
+    managed = set(installed).union(retained)
+    for slug in previous_slugs - managed:
+        if isinstance(slug, str) and local_slug_re.fullmatch(slug):
+            shutil.rmtree(os.path.join(skills_dir, slug), ignore_errors=True)
+
+    manifest = {"api_url": api_url.rstrip("/"), "skills": sorted(managed)}
+    tmp_manifest = manifest_path + ".tmp"
+    with open(tmp_manifest, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+    os.replace(tmp_manifest, manifest_path)
+
+    if not quiet:
+        print("")
+        print("  Synced %d skill(s) into %s" % (len(installed), skills_dir))
+        if failed:
+            print("  %d skill(s) failed; rerun the installer to retry." % len(failed), file=sys.stderr)
+    return 1 if failed and not installed and catalog else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+@router.get("/setup/codex-sync.py")
+def get_codex_sync_script():
+    return PlainTextResponse(_CODEX_SYNC_SCRIPT, media_type="text/x-python")
+
+
+_CODEX_SETUP_SCRIPT = r'''#!/bin/bash
+set -euo pipefail
+
+API_URL="__API_URL__"
+MCP_URL="__MCP_URL__"
+WEB_URL="__WEB_URL__"
+SKILLS_DIR="$HOME/.agents/skills"
+STATE_DIR="$HOME/.skillnote/codex"
+MANIFEST="$STATE_DIR/manifest.json"
+SYNC_SCRIPT="$STATE_DIR/sync.py"
+CODEX_DIR="$HOME/.codex"
+HOOKS_FILE="$CODEX_DIR/hooks.json"
+
+echo ""
+echo "  S K I L L N O T E   ->   C O D E X"
+echo ""
+
+# Windows commonly exposes a non-functional Microsoft Store `python3` alias.
+# Probe the interpreter instead of trusting `command -v`, then fall back to
+# the standard Windows `py -3` launcher when available.
+PYTHON_CMD=""
+PYTHON3_PATH=$(command -v python3 2>/dev/null || true)
+PYTHON_PATH=$(command -v python 2>/dev/null || true)
+case "$PYTHON3_PATH" in *WindowsApps*|*windowsapps*) PYTHON3_PATH="" ;; esac
+case "$PYTHON_PATH" in *WindowsApps*|*windowsapps*) PYTHON_PATH="" ;; esac
+
+if [ -n "$PYTHON3_PATH" ] && python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' &>/dev/null; then
+    PYTHON_CMD="python3"
+elif [ -n "$PYTHON_PATH" ] && python -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' &>/dev/null; then
+    PYTHON_CMD="python"
+elif command -v py &>/dev/null && py -3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 8) else 1)' &>/dev/null; then
+    PYTHON_CMD="py -3"
+else
+    echo "Error: Python 3.8 or newer is required."
+    exit 1
+fi
+mkdir -p "$SKILLS_DIR" "$STATE_DIR" "$CODEX_DIR"
+
+# Keep the refresher on disk so Codex can run it at session start. It only
+# replaces folders recorded in SkillNote's manifest; personal skills remain
+# untouched.
+curl -sf "$API_URL/setup/codex-sync.py" -o "$SYNC_SCRIPT"
+$PYTHON_CMD "$SYNC_SCRIPT" "$API_URL" "$SKILLS_DIR" "$MANIFEST"
+
+# Merge a SessionStart hook into the user's existing hooks.json. Codex asks
+# the user to review/trust new local hooks before it runs them.
+$PYTHON_CMD - "$HOOKS_FILE" "$PYTHON_CMD" "$SYNC_SCRIPT" "$API_URL" "$SKILLS_DIR" "$MANIFEST" <<'PYEOF'
+import json
+import os
+import shlex
+import subprocess
+import sys
+
+hooks_path, python_cmd, sync_script, api_url, skills_dir, manifest = sys.argv[1:]
+command_args = shlex.split(python_cmd) + [
+    sync_script, "--quiet", api_url, skills_dir, manifest,
+]
+command = (subprocess.list2cmdline(command_args) if os.name == "nt"
+           else shlex.join(command_args))
+try:
+    with open(hooks_path, encoding="utf-8") as handle:
+        root = json.load(handle)
+except FileNotFoundError:
+    root = {}
+except (OSError, ValueError) as exc:
+    print("  Warning: could not update %s: %s" % (hooks_path, exc), file=sys.stderr)
+    raise SystemExit(0)
+
+if not isinstance(root, dict):
+    print("  Warning: %s is not a JSON object; refresh hook was not installed." % hooks_path, file=sys.stderr)
+    raise SystemExit(0)
+events = root.setdefault("hooks", {})
+if not isinstance(events, dict):
+    print("  Warning: %s has an invalid hooks field; refresh hook was not installed." % hooks_path, file=sys.stderr)
+    raise SystemExit(0)
+groups = events.setdefault("SessionStart", [])
+if not isinstance(groups, list):
+    print("  Warning: %s has an invalid SessionStart field; refresh hook was not installed." % hooks_path, file=sys.stderr)
+    raise SystemExit(0)
+
+def is_skillnote_group(group):
+    if not isinstance(group, dict):
+        return False
+    return any(
+        isinstance(handler, dict)
+        and "skillnote/codex/sync.py" in str(handler.get("command", "")).replace("\\", "/")
+        for handler in group.get("hooks", [])
+    )
+
+groups[:] = [group for group in groups if not is_skillnote_group(group)]
+groups.append({
+    "matcher": "startup|resume|clear|compact",
+    "hooks": [{
+        "type": "command",
+        "command": command,
+        "timeout": 20,
+        "statusMessage": "Refreshing SkillNote skills",
+    }],
+})
+tmp_path = hooks_path + ".tmp"
+with open(tmp_path, "w", encoding="utf-8") as handle:
+    json.dump(root, handle, indent=2)
+    handle.write("\n")
+os.replace(tmp_path, hooks_path)
+PYEOF
+
+MACHINE_HASH=$(printf '%s' "${HOSTNAME:-host}-${USER:-user}" \
+    | shasum -a 256 2>/dev/null \
+    | awk '{print $1}' \
+    || echo "")
+$PYTHON_CMD - "$API_URL" "$MACHINE_HASH" <<'PYEOF' || true
+import json, sys, urllib.request
+url, machine_hash = sys.argv[1:]
+body = json.dumps({"agent": "codex", "machine_id_hash": machine_hash}).encode()
+request = urllib.request.Request(
+    url.rstrip("/") + "/v1/setup/installs",
+    data=body,
+    headers={"Content-Type": "application/json"},
+    method="POST",
+)
+urllib.request.urlopen(request, timeout=10).read()
+PYEOF
+
+echo ""
+if command -v codex &>/dev/null; then
+    codex mcp remove skillnote >/dev/null 2>&1 || true
+    if codex mcp add skillnote --url "$MCP_URL" >/dev/null 2>&1; then
+        echo "  Connected the SkillNote MCP server at $MCP_URL"
+    else
+        echo "  Warning: skills installed, but the SkillNote MCP server could not be configured."
+    fi
+    echo "  Codex CLI found. Start a new session and run /skills to browse."
+    echo "  In the terminal Codex CLI, run /hooks once and trust the SkillNote refresh hook."
+else
+    echo "  Skills are ready. Install Codex CLI, then start a session and run /skills."
+fi
+echo "  SkillNote will refresh managed skills whenever Codex starts or resumes."
+echo "  Web: $WEB_URL"
+echo ""
+'''
+
+
+@router.get("/setup/codex")
+def get_codex_setup_script(request: Request):
+    """Install the latest SkillNote registry skills for Codex CLI globally."""
+    urls = _derive_urls(request)
+    script = (_CODEX_SETUP_SCRIPT
+              .replace("__API_URL__", urls["api"])
+              .replace("__MCP_URL__", urls["mcp"])
+              .replace("__WEB_URL__", urls["web"]))
+    return PlainTextResponse(script, media_type="text/plain")
+
+
 # Unified entry point: parses --agent <name> from $@ and delegates to the
 # right per-agent installer. Keeps each installer's logic isolated (they
 # touch different home dirs, ship different bundles) while giving users one
@@ -629,6 +940,7 @@ def get_claude_ai_setup_script(request: Request):
 #
 #   curl -sf <host>/setup/agent | bash -s -- --agent openclaw
 #   curl -sf <host>/setup/agent | bash -s -- --agent claude-code
+#   curl -sf <host>/setup/agent | bash -s -- --agent codex
 _AGENT_DISPATCH_SCRIPT = r'''#!/bin/bash
 set -euo pipefail
 
@@ -655,7 +967,9 @@ Usage:
 
 Supported agents:
   claude-code   Install the SkillNote plugin for Claude Code
+  codex         Install registry skills globally for Codex CLI
   openclaw      Install the SkillNote skill for OpenClaw
+  claude-ai     Connect SkillNote to claude.ai in the browser
 
 Example:
   curl -sf $API_URL/setup/agent | bash -s -- --agent openclaw
@@ -679,7 +993,9 @@ if [ -z "$AGENT" ]; then
     echo ""
     echo "Supported agents:"
     echo "  claude-code   Install the SkillNote plugin for Claude Code"
+    echo "  codex         Install registry skills globally for Codex CLI"
     echo "  openclaw      Install the SkillNote skill for OpenClaw"
+    echo "  claude-ai     Connect SkillNote to claude.ai in the browser"
     exit 2
 fi
 
@@ -687,6 +1003,10 @@ case "$AGENT" in
     claude-code|claude_code|claude|cc)
         TARGET_PATH="/setup"
         AGENT_LABEL="Claude Code"
+        ;;
+    codex|codex-cli|codex_cli)
+        TARGET_PATH="/setup/codex"
+        AGENT_LABEL="Codex CLI"
         ;;
     openclaw|open-claw|oc)
         TARGET_PATH="/setup/openclaw"
@@ -699,7 +1019,7 @@ case "$AGENT" in
     *)
         echo "Error: unknown agent '$AGENT'."
         echo ""
-        echo "Supported agents: claude-code, openclaw, claude-ai"
+        echo "Supported agents: claude-code, codex, openclaw, claude-ai"
         exit 2
         ;;
 esac
@@ -808,16 +1128,35 @@ Please do the full install yourself — don't ask me to run commands.
 Don't ask for confirmation between steps. Just run the commands and report results.
 """
 
+_CODEX_AGENT_PROMPT = """Connect this Codex CLI installation to SkillNote at __API_URL__.
+
+Please do the setup yourself:
+
+1. Run the official SkillNote Codex installer:
+   ```bash
+   curl -sf __API_URL__/setup/agent | bash -s -- --agent codex
+   ```
+2. Verify that `~/.agents/skills/` contains the installed registry skills,
+   `~/.skillnote/codex/manifest.json` lists them, `~/.codex/hooks.json` has the
+   SkillNote `SessionStart` refresh hook, and `codex mcp list` shows the
+   `skillnote` server.
+3. Tell me to run `/hooks` once in the terminal Codex CLI (not the desktop app)
+   and trust the SkillNote refresh hook.
+4. Report how many skills were installed. If the current session does not see
+   them yet, remind me to start a new Codex session and run `/skills`.
+"""
+
 _AGENT_PROMPTS = {
     "openclaw": _OPENCLAW_AGENT_PROMPT,
     "claude-code": _CLAUDE_AGENT_PROMPT,
+    "codex": _CODEX_AGENT_PROMPT,
 }
 
 
 @router.get("/setup/agent-prompt")
 def get_agent_prompt(
     request: Request,
-    agent: str = Query(..., description="Target agent: openclaw or claude-code"),
+    agent: str = Query(..., description="Target agent: openclaw, claude-code, or codex"),
 ):
     """Returns a personalized install prompt with the user's host baked in.
 
@@ -834,6 +1173,7 @@ def get_agent_prompt(
         "openclaw": "openclaw", "oc": "openclaw", "open-claw": "openclaw",
         "claude-code": "claude-code", "cc": "claude-code",
         "claude": "claude-code", "claude_code": "claude-code",
+        "codex": "codex", "codex-cli": "codex", "codex_cli": "codex",
     }
     canonical = alias_map.get(agent_normalized)
     if canonical is None:
@@ -951,14 +1291,14 @@ def _agent_status(agent: AgentLiteral, db: Session) -> AgentStatus:
     # Both tables answer "when did this agent last call a skill?", but live
     # in different shapes — Claude Code logs to skill_call_events (one row
     # per skill call), OpenClaw logs to skill_usage_events (one row per
-    # session). We dispatch on agent name to pick the right source.
+    # session). Claude Code and Codex therefore share the same query shape.
     # `activity_floor` (from agent_disconnects) excludes any events at or
     # before the user's last explicit disconnect, so clicking Disconnect
     # actually flips the agent back to pending instead of staying "active"
     # forever from pre-disconnect activity.
     floor_clause = "AND created_at > :floor" if activity_floor is not None else ""
-    if agent == "claude-code":
-        params = {"agent": "claude-code"}
+    if agent in ("claude-code", "codex"):
+        params = {"agent": agent}
         if activity_floor is not None:
             params["floor"] = activity_floor  # type: ignore[assignment]
         last_active = db.execute(

--- a/backend/app/db/models/agent_install.py
+++ b/backend/app/db/models/agent_install.py
@@ -30,7 +30,7 @@ class AgentInstall(Base):
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     # Canonical agent name. Constrained at the application layer to the
-    # union we currently support (claude-code, openclaw); kept as TEXT in
+    # union we currently support (claude-code, codex, openclaw, claude-ai); kept as TEXT in
     # the DB so we can add agents without a schema migration.
     agent: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     # SHA-256 hex digest of a stable per-machine identifier — never the raw

--- a/backend/tests/unit/test_codex_setup.py
+++ b/backend/tests/unit/test_codex_setup.py
@@ -1,0 +1,60 @@
+from starlette.requests import Request
+
+from app.api.setup import (
+    SUPPORTED_AGENTS,
+    get_agent_dispatch_script,
+    get_agent_prompt,
+    get_codex_setup_script,
+)
+
+
+def _request() -> Request:
+    return Request({"type": "http", "headers": [(b"host", b"skillnote.test:8082")]})
+
+
+def test_codex_is_a_supported_agent() -> None:
+    assert "codex" in SUPPORTED_AGENTS
+
+
+def test_codex_installer_uses_official_global_skill_location() -> None:
+    script = get_codex_setup_script(_request()).body.decode()
+    assert 'SKILLS_DIR="$HOME/.agents/skills"' in script
+    assert 'MANIFEST="$STATE_DIR/manifest.json"' in script
+    assert 'SYNC_SCRIPT="$STATE_DIR/sync.py"' in script
+    assert 'HOOKS_FILE="$CODEX_DIR/hooks.json"' in script
+    assert 'PYTHON_CMD="py -3"' in script
+    assert '*WindowsApps*|*windowsapps*' in script
+    assert '$PYTHON_CMD "$SYNC_SCRIPT" "$API_URL" "$SKILLS_DIR" "$MANIFEST"' in script
+    assert '"SessionStart"' in script
+    assert 'startup|resume|clear|compact' in script
+    assert 'Refreshing SkillNote skills' in script
+    assert "subprocess.list2cmdline" in script
+    assert 'codex mcp add skillnote --url "$MCP_URL"' in script
+    assert '"agent": "codex"' in script
+
+
+def test_codex_sync_script_is_served_separately() -> None:
+    from app.api.setup import get_codex_sync_script
+
+    script = get_codex_sync_script().body.decode()
+    assert 'api_url.rstrip("/") + "/v1/skills"' in script
+    assert 'current/download' in script
+    assert 'content_version == 0' in script
+    assert 'urllib.parse.quote(source_slug, safe="")' in script
+    assert 'local_slug(source_slug)' in script
+    assert 'previous_slugs - managed' in script
+    assert 'destination already exists and is not managed by SkillNote' in script
+    assert "bundle contains a symbolic link" in script
+
+
+def test_unified_installer_dispatches_codex() -> None:
+    script = get_agent_dispatch_script(_request()).body.decode()
+    assert "codex|codex-cli|codex_cli)" in script
+    assert 'TARGET_PATH="/setup/codex"' in script
+
+
+def test_codex_copy_prompt_uses_resolved_host() -> None:
+    response = get_agent_prompt(_request(), agent="codex-cli")
+    prompt = response.body.decode()
+    assert "--agent codex" in prompt
+    assert "http://skillnote.test:8082" in prompt

--- a/cli/src/__tests__/agents.test.ts
+++ b/cli/src/__tests__/agents.test.ts
@@ -46,6 +46,18 @@ describe('agent adapters', () => {
     expect(adapter.skillDir('my-skill')).toBe(path.join(tmpDir, 'skills', 'my-skill'))
   })
 
+  it('detects Codex and installs user skills to the official global directory', async () => {
+    const { CodexAdapter } = await import('../agents/codex.js')
+    const adapter = new CodexAdapter(tmpDir)
+    expect(adapter.detect()).toBe(false)
+
+    fs.mkdirSync(path.join(tmpDir, '.codex'))
+    expect(adapter.detect()).toBe(true)
+    expect(adapter.skillDir('my-skill')).toBe(
+      path.join(tmpDir, '.agents', 'skills', 'my-skill'),
+    )
+  })
+
   it('detectAll returns only detected agents', async () => {
     const { detectAgents } = await import('../agents/index.js')
     fs.mkdirSync(path.join(tmpDir, '.claude'))

--- a/cli/src/agents/codex.ts
+++ b/cli/src/agents/codex.ts
@@ -6,13 +6,13 @@ export class CodexAdapter implements AgentAdapter {
   name = 'codex'
   displayName = 'Codex'
 
-  constructor(private projectDir: string) {}
+  constructor(private homeDir: string) {}
 
   detect(): boolean {
-    return fs.existsSync(path.join(this.projectDir, '.codex'))
+    return fs.existsSync(path.join(this.homeDir, '.codex'))
   }
 
   skillDir(slug: string): string {
-    return path.join(this.projectDir, '.codex', 'skills', slug)
+    return path.join(this.homeDir, '.agents', 'skills', slug)
   }
 }

--- a/cli/src/agents/index.ts
+++ b/cli/src/agents/index.ts
@@ -14,7 +14,7 @@ export function allAdapters(projectDir: string, homeDir?: string): AgentAdapter[
   return [
     new ClaudeAdapter(projectDir),
     new CursorAdapter(projectDir),
-    new CodexAdapter(projectDir),
+    new CodexAdapter(home),
     new OpenClawAdapter(projectDir, home),
     new OpenHandsAdapter(projectDir),
     new UniversalAdapter(projectDir),

--- a/cli/src/commands/connect.ts
+++ b/cli/src/commands/connect.ts
@@ -5,7 +5,7 @@ import { UserFacingError, prettyError } from '../ui/errors.js'
 import { c } from '../ui/theme.js'
 
 // Supported agent identifiers, matching the backend's /setup/agent dispatcher.
-export const SUPPORTED_AGENTS = ['claude-code', 'openclaw', 'claude-ai'] as const
+export const SUPPORTED_AGENTS = ['claude-code', 'codex', 'openclaw', 'claude-ai'] as const
 export type SupportedAgent = (typeof SUPPORTED_AGENTS)[number]
 
 export interface ConnectOptions {
@@ -14,6 +14,7 @@ export interface ConnectOptions {
 
 const displayNames: Record<SupportedAgent, string> = {
   'claude-code': 'Claude Code',
+  codex: 'Codex CLI',
   openclaw: 'OpenClaw',
   'claude-ai': 'claude.ai (browser)',
 }
@@ -82,6 +83,15 @@ export async function connectCommand(agent: string, _opts: ConnectOptions = {}):
           '  1. Open a new shell (or run `source ~/.zshrc`)',
           '  2. Run `claude`',
           '  3. The skill picker appears',
+        ].join('\n'),
+      )
+    } else if (agent === 'codex') {
+      log.info(
+        [
+          'Next:',
+          '  1. Start a new Codex session with `codex`',
+          '  2. In the terminal Codex CLI, run `/hooks` once and trust the SkillNote refresh hook',
+          '  3. Run `/skills` or type `$` to browse SkillNote skills',
         ].join('\n'),
       )
     } else if (agent === 'openclaw') {

--- a/cli/src/commands/disconnect.ts
+++ b/cli/src/commands/disconnect.ts
@@ -1,7 +1,8 @@
-import { rm } from 'node:fs/promises'
+import { readFile, rm, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { confirm, intro, log, outro, spinner } from '@clack/prompts'
+import { execa } from 'execa'
 import { isInteractive } from '../lib/system.js'
 import { UserFacingError, prettyError } from '../ui/errors.js'
 import { c } from '../ui/theme.js'
@@ -28,6 +29,8 @@ export async function disconnectCommand(
 
     if (agent === 'openclaw') {
       await disconnectOpenClaw(opts)
+    } else if (agent === 'codex') {
+      await disconnectCodex(opts)
     } else if (agent === 'claude-code') {
       await disconnectClaudeCode(opts)
     }
@@ -40,6 +43,84 @@ export async function disconnectCommand(
       return
     }
     throw err
+  }
+}
+
+async function disconnectCodex(opts: DisconnectOptions): Promise<void> {
+  const stateDir = join(homedir(), '.skillnote', 'codex')
+  const manifestPath = join(stateDir, 'manifest.json')
+  let slugs: string[]
+  try {
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as { skills?: unknown }
+    slugs = Array.isArray(manifest.skills)
+      ? manifest.skills.filter(
+          (slug): slug is string =>
+            typeof slug === 'string' && /^[a-z0-9][a-z0-9-]{0,127}$/.test(slug),
+        )
+      : []
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      log.info('No SkillNote-managed Codex skills were found.')
+      slugs = []
+    } else {
+      throw new UserFacingError({
+        header: 'Could not read the Codex install manifest',
+        body: manifestPath,
+        remediation: 'Inspect or repair the manifest before removing managed skill folders.',
+      })
+    }
+  }
+
+  const proceed = await confirmIfNeeded(
+    opts.yes,
+    `Remove ${slugs.length} SkillNote-managed Codex skill(s)?`,
+  )
+  if (!proceed) {
+    log.info('Aborted. Nothing changed.')
+    return
+  }
+
+  const s = spinner()
+  s.start('Removing SkillNote-managed Codex skills')
+  const skillsDir = join(homedir(), '.agents', 'skills')
+  for (const slug of slugs) {
+    await rm(join(skillsDir, slug), { recursive: true, force: true })
+  }
+  await removeCodexRefreshHook()
+  await execa('codex', ['mcp', 'remove', 'skillnote'], { reject: false }).catch(() => undefined)
+  await rm(stateDir, { recursive: true, force: true })
+  s.stop(`Removed ${slugs.length} managed skill(s)`)
+}
+
+async function removeCodexRefreshHook(): Promise<void> {
+  const hooksPath = join(homedir(), '.codex', 'hooks.json')
+  try {
+    const root = JSON.parse(await readFile(hooksPath, 'utf8')) as {
+      hooks?: { SessionStart?: unknown }
+    }
+    const hooks = root.hooks
+    if (!hooks) return
+    const groups = hooks.SessionStart
+    if (!Array.isArray(groups)) return
+
+    hooks.SessionStart = groups.filter((group) => {
+      if (!group || typeof group !== 'object') return true
+      const handlers = (group as { hooks?: unknown }).hooks
+      if (!Array.isArray(handlers)) return true
+      return !handlers.some((handler) => {
+        if (!handler || typeof handler !== 'object') return false
+        const command = (handler as { command?: unknown }).command
+        return (
+          typeof command === 'string' &&
+          command.replaceAll('\\', '/').includes('skillnote/codex/sync.py')
+        )
+      })
+    })
+    await writeFile(hooksPath, `${JSON.stringify(root, null, 2)}\n`, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log.warn(`Could not remove the SkillNote refresh hook from ${hooksPath}.`)
+    }
   }
 }
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -104,13 +104,13 @@ program
 
 program
   .command('connect <agent>')
-  .description('Connect an agent (claude-code, openclaw) to SkillNote')
+  .description('Connect an agent (claude-code, codex, openclaw) to SkillNote')
   .option('-y, --yes', 'Skip confirmation prompts')
   .action((agent, opts) => connectCommand(agent, opts))
 
 program
   .command('disconnect <agent>')
-  .description('Disconnect an agent (claude-code, openclaw)')
+  .description('Disconnect an agent (claude-code, codex, openclaw)')
   .option('-y, --yes', 'Skip confirmation prompts')
   .action((agent, opts) => disconnectCommand(agent, opts))
 

--- a/cli/tests/unit/connect.test.ts
+++ b/cli/tests/unit/connect.test.ts
@@ -20,6 +20,7 @@ afterEach(() => {
 describe('SUPPORTED_AGENTS', () => {
   it('exports the canonical list', () => {
     expect(SUPPORTED_AGENTS).toContain('claude-code')
+    expect(SUPPORTED_AGENTS).toContain('codex')
     expect(SUPPORTED_AGENTS).toContain('openclaw')
   })
 })

--- a/e2e/integrations-page.spec.ts
+++ b/e2e/integrations-page.spec.ts
@@ -11,7 +11,7 @@
 import { test, expect, type Page } from '@playwright/test'
 
 interface AgentRow {
-  agent: 'claude-code' | 'openclaw'
+  agent: 'claude-code' | 'codex' | 'openclaw' | 'claude-ai'
   state: 'pending' | 'active' | 'idle'
   installed_at: string | null
   last_active_at: string | null
@@ -114,6 +114,20 @@ test.describe('/integrations — Browse cards + Connected rows', () => {
     // Each card has an "Install" affordance (the role-button div in the footer)
     const installButtons = page.getByText('Install', { exact: true })
     await expect(installButtons.first()).toBeVisible()
+  })
+
+  test('Browse includes a Codex CLI connection', async ({ page }) => {
+    await mockSetup(page, [
+      { agent: 'claude-code', state: 'pending', installed_at: null, last_active_at: null, calls_24h: 0, calls_7d: 0 },
+      { agent: 'codex', state: 'pending', installed_at: null, last_active_at: null, calls_24h: 0, calls_7d: 0 },
+      { agent: 'openclaw', state: 'pending', installed_at: null, last_active_at: null, calls_24h: 0, calls_7d: 0 },
+    ])
+    await page.goto('/integrations')
+    await page.getByRole('tab', { name: /Browse/ }).click()
+
+    await expect(page.getByText('Codex CLI', { exact: true })).toBeVisible()
+    await expect(page.getByText('OpenAI coding agent', { exact: true })).toBeVisible()
+    await expect(page.getByRole('tab', { name: /Browse 3/ })).toBeVisible()
   })
 
   test('Browse cards swap to "Connected" footer state when agent is active', async ({ page }) => {

--- a/public/codex-mark.svg
+++ b/public/codex-mark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="OpenAI Codex">
+  <rect width="64" height="64" rx="12" fill="#101010"/>
+  <path d="M20 20.5 9 32l11 11.5M44 20.5 55 32 44 43.5" fill="none" stroke="#fff" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m36.5 15-9 34" stroke="#7ee2b8" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/app/(app)/integrations/page.tsx
+++ b/src/app/(app)/integrations/page.tsx
@@ -9,7 +9,7 @@ import { AgentCard } from '@/components/integrations/agent-card'
 import { AgentListRow } from '@/components/integrations/agent-list-row'
 import { ConnectModal } from '@/components/integrations/connect-modal'
 import { DisconnectModal } from '@/components/integrations/disconnect-modal'
-import { ClaudeCodeMark, OpenClawMark } from '@/components/integrations/agent-marks'
+import { ClaudeCodeMark, CodexMark, OpenClawMark } from '@/components/integrations/agent-marks'
 import {
   ClaudeAICard,
   ClaudeAIConnectedRow,
@@ -19,7 +19,9 @@ import type { ConnectionState } from '@/components/integrations/connector'
 import { getApiBaseUrl } from '@/lib/api/client'
 import { dispatchJob, useJobPolling, type JobAgent } from '@/lib/cli-jobs'
 
-type AgentId = 'claude-code' | 'openclaw'
+// claude.ai uses the browser-extension pairing flow below rather than the
+// CLI job/snapshot lifecycle shared by installed agents.
+type AgentId = Exclude<JobAgent, 'claude-ai'>
 
 interface AgentSnapshot {
   id: AgentId
@@ -71,6 +73,21 @@ const AGENTS: AgentMeta[] = [
     ],
   },
   {
+    id: 'codex',
+    label: 'Codex CLI',
+    sublabel: 'OpenAI coding agent',
+    description:
+      'OpenAI\'s terminal coding agent. SkillNote installs your registry skills globally so they are available in every Codex workspace.',
+    platforms: ['macOS', 'Linux', 'Windows'],
+    badge: 'official',
+    usageSteps: [
+      'Start a new Codex session with `codex`.',
+      'In the terminal Codex CLI, run `/hooks` once and trust the SkillNote refresh hook (the desktop app does not expose this command).',
+      'Run `/skills` or type `$` to browse your SkillNote skills.',
+      'New and edited skills refresh whenever Codex starts or resumes.',
+    ],
+  },
+  {
     id: 'openclaw',
     label: 'OpenClaw',
     sublabel: 'Open-source agent runtime',
@@ -101,6 +118,7 @@ export default function IntegrationsPage() {
   const [overrides, setOverrides] = useState<Partial<Record<AgentId, ConnectionState>>>({})
   const [snapshots, setSnapshots] = useState<Record<AgentId, AgentSnapshot>>({
     'claude-code': { id: 'claude-code', state: 'pending' },
+    codex: { id: 'codex', state: 'pending' },
     openclaw: { id: 'openclaw', state: 'pending' },
   })
   // Flips true after the first successful /v1/setup/agents fetch so the
@@ -247,6 +265,7 @@ export default function IntegrationsPage() {
     }
     return {
       'claude-code': apply(snapshots['claude-code']),
+      codex: apply(snapshots.codex),
       openclaw: apply(snapshots.openclaw),
     } as Record<AgentId, AgentSnapshot>
   }, [snapshots, overrides])
@@ -256,9 +275,9 @@ export default function IntegrationsPage() {
   // Windows prefixes `wsl ` because the install scripts only run inside a
   // POSIX shell. The Advanced drawer explains the WSL caveat to the user.
   const baseCmd = (id: AgentId) =>
-    id === 'claude-code'
-      ? `curl -sf ${base}/setup/agent | bash -s -- --agent claude-code`
-      : `curl -sf ${base}/setup/openclaw | bash`
+    id === 'openclaw'
+      ? `curl -sf ${base}/setup/openclaw | bash`
+      : `curl -sf ${base}/setup/agent | bash -s -- --agent ${id}`
 
   const installCmd = (id: AgentId) => baseCmd(id)
 
@@ -284,7 +303,16 @@ export default function IntegrationsPage() {
           'Shell wrapper — appended to ~/.zshrc or ~/.bashrc',
           `Bridge daemon — ${base}`,
         ]
-      : [
+      : id === 'codex'
+        ? [
+          'Global skill root — ~/.agents/skills/',
+          'Managed-skill manifest — ~/.skillnote/codex/manifest.json',
+          'Refresh hook — ~/.codex/hooks.json (SessionStart)',
+          'MCP server — ~/.codex/config.toml (skillnote)',
+          'Registry source — latest active SkillNote versions',
+          `Bridge daemon — ${base}`,
+        ]
+        : [
           'Skill root — ~/.openclaw/skills/skillnote/',
           'Refresh hook — ~/.openclaw/skills/skillnote/sync.sh',
           'Analytics agent — ~/.openclaw/skills/skillnote/log-watcher.py',
@@ -327,7 +355,7 @@ export default function IntegrationsPage() {
   )
 
   const markFor = (id: AgentId) =>
-    id === 'claude-code' ? <ClaudeCodeMark /> : <OpenClawMark />
+    id === 'claude-code' ? <ClaudeCodeMark /> : id === 'codex' ? <CodexMark /> : <OpenClawMark />
 
   // Connected = agents in active or idle state. Everything else is browseable.
   const connected = AGENTS.filter((a) => {
@@ -537,7 +565,9 @@ export default function IntegrationsPage() {
 }
 
 function labelOf(id: AgentId): string {
-  return id === 'claude-code' ? 'Claude Code' : 'OpenClaw'
+  if (id === 'claude-code') return 'Claude Code'
+  if (id === 'codex') return 'Codex CLI'
+  return 'OpenClaw'
 }
 
 // ─── Empty state for the Connected tab ────────────────────────────────────
@@ -566,7 +596,7 @@ function EmptyConnected({ onBrowse }: { onBrowse: () => void }) {
         No agents connected yet
       </p>
       <p className="mx-auto mt-1.5 max-w-sm text-[12.5px] text-muted-foreground/85 leading-relaxed">
-        Wire in Claude Code or OpenClaw and SkillNote will sync your skills,
+        Wire in Claude Code, Codex CLI, or OpenClaw and SkillNote will sync your skills,
         stream usage analytics, and let you publish skills with one command.
       </p>
       <div className="mt-5 flex items-center justify-center gap-2">
@@ -653,6 +683,7 @@ function DevCycler({
         Dev state cycler
       </p>
       <Btn id="claude-code" label="claude" />
+      <Btn id="codex" label="codex" />
       <Btn id="openclaw" label="openclaw" />
     </div>
   )

--- a/src/components/integrations/action-panel.tsx
+++ b/src/components/integrations/action-panel.tsx
@@ -7,13 +7,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { getApiBaseUrl } from '@/lib/api/client'
 import { cn } from '@/lib/utils'
 import type { ConnectionState } from './connector'
+import type { JobAgent } from '@/lib/cli-jobs'
 
 export type PlatformId = 'macos' | 'linux' | 'windows'
 export type PlatformCommands = Record<PlatformId, string>
 
 interface Props {
   state: ConnectionState
-  agentId: 'claude-code' | 'openclaw'
+  agentId: JobAgent
   agentLabel: string
   installCommand: string
   /** Install command per platform; shown in the Advanced drawer's platform tabs. */
@@ -217,7 +218,7 @@ function AdvancedDrawer({
   platformCommands,
   installManifest,
 }: {
-  agentId: 'claude-code' | 'openclaw'
+  agentId: JobAgent
   platformCommands: PlatformCommands
   installManifest: string[]
 }) {

--- a/src/components/integrations/agent-list-row.tsx
+++ b/src/components/integrations/agent-list-row.tsx
@@ -6,10 +6,11 @@ import { cn } from '@/lib/utils'
 import { ConnectionDiagram } from './connection-diagram'
 import { ActionPanel, type PlatformCommands } from './action-panel'
 import type { ConnectionState } from './connector'
+import type { JobAgent } from '@/lib/cli-jobs'
 
 interface Props {
   state: ConnectionState
-  agentId: 'claude-code' | 'openclaw'
+  agentId: JobAgent
   agentLabel: string
   agentSublabel?: string
   agentMark: React.ReactNode

--- a/src/components/integrations/agent-marks.tsx
+++ b/src/components/integrations/agent-marks.tsx
@@ -89,3 +89,16 @@ export function ClaudeAIMark({ size = 56 }: { size?: number }) {
     />
   )
 }
+
+export function CodexMark({ size = 56 }: { size?: number }) {
+  return (
+    <img
+      src="/codex-mark.svg"
+      alt="OpenAI Codex"
+      width={size}
+      height={size}
+      className="block rounded-lg"
+      draggable={false}
+    />
+  )
+}

--- a/src/lib/cli-jobs.ts
+++ b/src/lib/cli-jobs.ts
@@ -14,7 +14,7 @@ import { apiRequest } from '@/lib/api/client'
 
 export type JobStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled'
 export type JobType = 'connect' | 'disconnect' | 'reconnect' | 'open'
-export type JobAgent = 'claude-code' | 'openclaw'
+export type JobAgent = 'claude-code' | 'codex' | 'openclaw' | 'claude-ai'
 
 export type CliJob = {
   id: string


### PR DESCRIPTION
## Summary
- add Codex as a first-class SkillNote integration across the API, CLI, and web UI
- install and refresh SkillNote-managed skills in Codex's user-global skill directory without overwriting personal skills
- sync current UI-authored/imported skill content and normalize Windows-incompatible skill names
- preserve and compose with the new claude.ai integration from master

## Validation
- `npx tsc --noEmit`
- `cd cli && npm run typecheck`
- `cd cli && npm test -- --run src/__tests__/agents.test.ts tests/unit/connect.test.ts` (12 tests)
- Python compilation checks for the changed backend modules

Docker Desktop was unavailable for a post-rebase backend container rerun; the five focused Codex backend tests passed before rebasing onto current master.