### PR TITLE
fix(ci): bake web /v1 proxy target into GHCR images

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -32,8 +32,15 @@ jobs:
           - name: web
             context: .
             dockerfile: Dockerfile
+            # SKILLNOTE_API_PROXY_TARGET must be set at BUILD time: next.config.ts
+            # resolves rewrites() during `next build`, so the /v1/* proxy destination
+            # is baked into the image's routes-manifest. Both docker-compose.yml and
+            # the CLI's compose template run the backend as service `api` on :8080.
+            # Without this arg the proxy targets localhost:8082 — the web container
+            # itself — and every /v1/* request through the web origin 500s.
             build_args: |
               NEXT_PUBLIC_API_BASE_URL=http://localhost:8082
+              SKILLNOTE_API_PROXY_TARGET=http://api:8080
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

`http://<web-host>:3000/v1/*` returns **500** on every GHCR-image deployment (including CLI-managed stacks from `skillnote start`). Found while smoke-testing the 0.7.1 release; the 0.6.0 image has the same defect.

Next.js resolves `rewrites()` at **build** time and freezes the destination into the image's `routes-manifest.json`. `docker-images.yml` never passed `SKILLNOTE_API_PROXY_TARGET`, so published web images bake the dev default `http://localhost:8082` — which, inside the web container, is the web container itself:

```json
{ "source": "/v1/:path*", "destination": "http://localhost:8082/v1/:path*" }
```

This breaks the documented pairing path (clients pair with the **web** URL; the web origin proxies `/v1/*`). CLI/plugins are unaffected — they hit `:8082` directly.

## Fix

Pass `SKILLNOTE_API_PROXY_TARGET=http://api:8080` as a build arg, matching what `docker-compose.yml` already does for local full-stack builds. The CLI's compose template runs the backend under the same service name (`api`) and container port (`8080`), so one baked value serves both deployment shapes.

## Verification

- Built the image locally with the arg: `routes-manifest.json` now targets `http://api:8080/v1/:path*`.
- Ran that image attached to a live stack's compose network: `curl :3000/v1/skills` through the web origin returned all 7 skills (previously 500).

## After merge

Re-dispatch the **Docker Images** workflow with version `0.7.1` to republish the fixed `skillnote-web:0.7.1` + `latest` (api image is unaffected but rebuilds harmlessly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)